### PR TITLE
Fix hard-coded call to gcc in GCC version check

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -107,7 +107,7 @@ LIBWANDIO_LIBS=""
 # Set our C compiler flags based on the gcc version
 if test "$GCC" = "yes"; then
 	
-	gcc_version=`gcc -dumpversion`
+	gcc_version=`$CC -dumpversion`
 
 	# This is probably not the most reliable way to test whether our
 	# compiler supports visibility, but it's better than nothing


### PR DESCRIPTION
FreeBSD 10 does not have gcc by default, but the clang compiler does support GCC
features. Replaced the hard-coded gcc command with $CC.
Tested on FreeBSD 10, Ubuntu 12.04.4 and Mac OSX 10.9.3
