### PR TITLE
BUG: Makefile dependencies are not correct for tools using libwandio

### DIFF
--- a/README
+++ b/README
@@ -1,5 +1,7 @@
 libtrace 3.0.20
 
+
+
 ---------------------------------------------------------------------------
 Copyright (c) 2007-2014 The University of Waikato, Hamilton, New Zealand.
 All rights reserved.


### PR DESCRIPTION
when doing make -j9 (using 8 parallel cores to build) the build will fail trying to compile  `wandiocat` and maybe others that depend on libwandio - because libwandio was not created yet.
this could be fixed by making libwandio.la a dependency of wandiocat (and possibly other tools requiring the lib).

i'm using this bogus pull request to report the issue, since you disabled the github issue tracker and i cant be bothered to register at yet another mailing list or proprietary bug tracker.
i cant even be bothered to search its URL.
