### PR TITLE
change buffer length types from int to off_t

### DIFF
--- a/libwandio/ior-peek.c
+++ b/libwandio/ior-peek.c
@@ -61,8 +61,8 @@
 struct peek_t {
 	io_t *child;
 	char *buffer;
-	int length; /* Length of buffer */
-	int offset; /* Offset into buffer */
+	off_t length; /* Length of buffer */
+	off_t offset; /* Offset into buffer */
 };
 
 extern io_source_t peek_source;


### PR DESCRIPTION
previously the length of the buffer in the peek reader was stored in an int. when
a large read (> INT32_MAX) was requested, the buffer-resize malloc (ior-peek.c:129)
would fail, and therefore trigger the assert on line 135.

this bug was triggered, and the fix tested, on FreeBSD 10.
