### PR TITLE
Fix issue #49 compile issues when missing BPF header file

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -249,7 +249,6 @@ else
 	TOOL_LIBS="$TOOL_LIBS -lpcap"
 	LIBTRACE_LIBS="$LIBTRACE_LIBS -lpcap"
 	AC_DEFINE([HAVE_LIBPCAP],1,[compile with libpcap support])
-	AC_DEFINE([HAVE_BPF_FILTER],1,[compile with bpf filter support])
 
 	LIBS="-lpcap"
 	AC_CHECK_FUNCS(pcap_inject pcap_sendpacket pcap_setnonblock)

--- a/lib/format_linux_common.c
+++ b/lib/format_linux_common.c
@@ -60,7 +60,7 @@ int linuxcommon_probe_filename(const char *filename)
 /* Compiles a libtrace BPF filter for use with a linux native socket */
 static int linuxnative_configure_bpf(libtrace_t *libtrace,
 		libtrace_filter_t *filter) {
-#ifdef HAVE_LIBPCAP
+#if defined(HAVE_LIBPCAP) && defined(HAVE_BPF)
 	struct ifreq ifr;
 	unsigned int arphrd;
 	libtrace_dlt_t dlt;
@@ -124,7 +124,7 @@ static int linuxnative_configure_bpf(libtrace_t *libtrace,
 
 	return 0;
 #else
-	return -1
+	return -1;
 #endif
 }
 
@@ -403,6 +403,7 @@ int linuxcommon_start_input_stream(libtrace_t *libtrace,
 	 * that the filterstring has been compiled, or the filter was supplied
 	 * pre-compiled.
 	 */
+#ifdef HAVE_BPF
 	if (filter != NULL) {
 		/* Check if the filter was successfully compiled. If not,
 		 * it is probably a bad filter and we should return an error
@@ -423,6 +424,7 @@ int linuxcommon_start_input_stream(libtrace_t *libtrace,
 			perror("setsockopt(SO_ATTACH_FILTER)");
 		}
 	}
+#endif
 
 	/* Consume any buffered packets that were received before the socket
 	 * was properly setup, including those which missed the filter and

--- a/lib/format_pcap.c
+++ b/lib/format_pcap.c
@@ -127,6 +127,7 @@ static int pcap_start_input(libtrace_t *libtrace) {
 	}
 
 	/* If a filter has been configured, compile and apply it */
+#ifdef HAVE_BPF
 	if (DATA(libtrace)->filter) {
 		if (DATA(libtrace)->filter->flag == 0) {
 			pcap_compile(INPUT.pcap, 
@@ -142,6 +143,7 @@ static int pcap_start_input(libtrace_t *libtrace) {
 			return -1;
 		}
 	}
+#endif
 	return 0;
 }
 
@@ -151,8 +153,12 @@ static int pcap_config_input(libtrace_t *libtrace,
 {
 	switch(option) {
 		case TRACE_OPTION_FILTER:
+#ifdef HAVE_BPF
 			DATA(libtrace)->filter=data;
 			return 0;
+#else
+			return -1;
+#endif
 		case TRACE_OPTION_SNAPLEN:
 			/* Snapping isn't supported directly, so fall thru
 			 * and let libtrace deal with it
@@ -210,8 +216,12 @@ static int pcapint_config_input(libtrace_t *libtrace,
 {
 	switch(option) {
 		case TRACE_OPTION_FILTER:
+#ifdef HAVE_BPF
 			DATA(libtrace)->filter=(libtrace_filter_t*)data;
 			return 0;
+#else
+			return -1;
+#endif
 		case TRACE_OPTION_SNAPLEN:
 			DATA(libtrace)->snaplen=*(int*)data;
 			return 0;
@@ -297,6 +307,7 @@ static int pcapint_start_input(libtrace_t *libtrace) {
 	pcap_setnonblock(INPUT.pcap,0,errbuf);
 #endif
 	/* Set a filter if one is defined */
+#ifdef HAVE_BPF
 	if (DATA(libtrace)->filter) {
 		struct pcap_pkthdr *pcap_hdr = NULL;
 		u_char *pcap_payload = NULL;
@@ -341,6 +352,7 @@ static int pcapint_start_input(libtrace_t *libtrace) {
                 if (pcapret < 0)
                         return -1;
 	}
+#endif
 	return 0; /* success */
 }
 

--- a/lib/trace.c
+++ b/lib/trace.c
@@ -1349,7 +1349,7 @@ DLLEXPORT libtrace_eventobj_t trace_event(libtrace_t *trace,
 DLLEXPORT libtrace_filter_t *
 trace_create_filter_from_bytecode(void *bf_insns, unsigned int bf_len)
 {
-#ifndef HAVE_BPF_FILTER
+#ifndef HAVE_BPF
 	fprintf(stderr, "This version of libtrace does not have BPF support\n");
 	return NULL;
 #else
@@ -1376,7 +1376,7 @@ trace_create_filter_from_bytecode(void *bf_insns, unsigned int bf_len)
  * @returns opaque pointer pointer to a libtrace_filter_t object
  */
 DLLEXPORT libtrace_filter_t *trace_create_filter(const char *filterstring) {
-#ifdef HAVE_BPF_FILTER
+#ifdef HAVE_BPF
 	libtrace_filter_t *filter = (libtrace_filter_t*)
 				malloc(sizeof(libtrace_filter_t));
 	filter->filterstring = strdup(filterstring);
@@ -1391,7 +1391,7 @@ DLLEXPORT libtrace_filter_t *trace_create_filter(const char *filterstring) {
 
 DLLEXPORT void trace_destroy_filter(libtrace_filter_t *filter)
 {
-#ifdef HAVE_BPF_FILTER
+#ifdef HAVE_BPF
 	free(filter->filterstring);
 	if (filter->flag)
 		pcap_freecode(&filter->filter);
@@ -1416,7 +1416,7 @@ static int trace_bpf_compile(libtrace_filter_t *filter,
 		const libtrace_packet_t *packet,
 		void *linkptr,
 		libtrace_linktype_t linktype	) {
-#ifdef HAVE_BPF_FILTER
+#ifdef HAVE_BPF
 	/* It just so happens that the underlying libs used by pthread arn't
 	 * thread safe, namely lex/flex thingys, so single threaded compile
 	 * multi threaded running should be safe.
@@ -1480,7 +1480,7 @@ static int trace_bpf_compile(libtrace_filter_t *filter,
 
 DLLEXPORT int trace_apply_filter(libtrace_filter_t *filter,
 			const libtrace_packet_t *packet) {
-#ifdef HAVE_BPF_FILTER
+#ifdef HAVE_BPF
 	void *linkptr = 0;
 	uint32_t clen = 0;
 	bool free_packet_needed = false;


### PR DESCRIPTION
I'm still not sure how it is possible to install pcap without the BPF header.
But if this situation occurs this patch allows libtrace to compile without BPF support.