### PR TITLE
Add TRACE_ERR_WANDIO_FAILED for wandio error reporting.

### DIFF
--- a/lib/format_atmhdr.c
+++ b/lib/format_atmhdr.c
@@ -136,7 +136,7 @@ static int atmhdr_read_packet(libtrace_t *libtrace, libtrace_packet_t *packet) {
 	if ((numbytes=wandio_read(libtrace->io, buffer, (size_t)12)) != 12)
 	{
 		if (numbytes != 0) {
-			trace_set_err(libtrace,errno,"read(%s)",libtrace->uridata);
+			trace_set_err(libtrace,TRACE_ERR_WANDIO_FAILED,"read(%s)",libtrace->uridata);
 		}
 		return numbytes;
 	}

--- a/lib/format_legacy.c
+++ b/lib/format_legacy.c
@@ -268,7 +268,7 @@ static int legacy_read_packet(libtrace_t *libtrace, libtrace_packet_t *packet) {
 						buffer,
 						(size_t)64)) != 64) {
 			if (numbytes < 0) {
-				trace_set_err(libtrace,errno,"read(%s)",libtrace->uridata);
+				trace_set_err(libtrace,TRACE_ERR_WANDIO_FAILED,"read(%s)",libtrace->uridata);
 			} else if (numbytes > 0) {
 				
 				continue;
@@ -309,7 +309,7 @@ static int legacynzix_read_packet(libtrace_t *libtrace, libtrace_packet_t *packe
 		if ((numbytes = wandio_read(libtrace->io, buffer,
 						(size_t)68)) != 68) {
 			if (numbytes < 0) {
-				trace_set_err(libtrace,errno,"read(%s)",libtrace->uridata);
+				trace_set_err(libtrace,TRACE_ERR_WANDIO_FAILED,"read(%s)",libtrace->uridata);
 			} else if (numbytes > 0)
 				continue;
 			return numbytes;

--- a/lib/format_pcapfile.c
+++ b/lib/format_pcapfile.c
@@ -356,7 +356,7 @@ static int pcapfile_read_packet(libtrace_t *libtrace, libtrace_packet_t *packet)
 			packet->buffer,
 			sizeof(libtrace_pcapfile_pkt_hdr_t));
 	if (err<0) {
-		trace_set_err(libtrace,errno,"reading packet");
+		trace_set_err(libtrace,TRACE_ERR_WANDIO_FAILED,"reading packet");
 		return -1;
 	}
 	if (err==0) {
@@ -365,7 +365,7 @@ static int pcapfile_read_packet(libtrace_t *libtrace, libtrace_packet_t *packet)
 	}
 
         if (err < (int)sizeof(libtrace_pcapfile_pkt_hdr_t)) {
-                trace_set_err(libtrace, errno, "Incomplete pcap packet header");
+                trace_set_err(libtrace, TRACE_ERR_BAD_PACKET, "Incomplete pcap packet header");
                 return -1;
         }
 
@@ -392,7 +392,7 @@ static int pcapfile_read_packet(libtrace_t *libtrace, libtrace_packet_t *packet)
 			);
 
 	if (err<0) {
-		trace_set_err(libtrace,errno,"reading packet");
+		trace_set_err(libtrace,TRACE_ERR_WANDIO_FAILED,"reading packet");
 		return -1;
 	}
 	if (err==0) {
@@ -400,7 +400,7 @@ static int pcapfile_read_packet(libtrace_t *libtrace, libtrace_packet_t *packet)
 	}
 
         if (err < (int)bytes_to_read) {
-                trace_set_err(libtrace, errno, "Incomplete pcap packet body");
+                trace_set_err(libtrace, TRACE_ERR_WANDIO_FAILED, "Incomplete pcap packet body");
                 return -1;
         }
 

--- a/lib/format_pcapng.c
+++ b/lib/format_pcapng.c
@@ -329,7 +329,7 @@ static inline int skip_block(libtrace_t *libtrace, uint32_t toread) {
 
                 err = wandio_read(libtrace->io, buf, nextread);
                 if (err < 0) {
-                        trace_set_err(libtrace, errno,
+                        trace_set_err(libtrace, TRACE_ERR_WANDIO_FAILED,
                                 "Reading section header options");
                         return -1;
                 }
@@ -350,7 +350,7 @@ static inline int pcapng_read_body(libtrace_t *libtrace, char *body,
 
         err = wandio_read(libtrace->io, body, to_read);
         if (err < 0) {
-                trace_set_err(libtrace, errno,
+                trace_set_err(libtrace, TRACE_ERR_WANDIO_FAILED,
                         "Failed to read pcapng interface options");
                 return err;
         }
@@ -443,7 +443,7 @@ static int pcapng_read_section(libtrace_t *libtrace,
         sechdr = (pcapng_sec_t *)packet->buffer;
 
         if (err < 0) {
-                trace_set_err(libtrace, errno,
+                trace_set_err(libtrace, TRACE_ERR_WANDIO_FAILED,
                         "Reading pcapng section header block");
                 return -1;
         }
@@ -518,7 +518,7 @@ static int pcapng_read_interface(libtrace_t *libtrace,
         err = wandio_read(libtrace->io, packet->buffer, sizeof(pcapng_int_t));
 
         if (err < 0) {
-                trace_set_err(libtrace, errno,
+                trace_set_err(libtrace, TRACE_ERR_WANDIO_FAILED,
                         "Reading pcapng interface header block");
                 return -1;
         }
@@ -625,7 +625,7 @@ static int pcapng_read_nrb(libtrace_t *libtrace, libtrace_packet_t *packet,
         err = wandio_read(libtrace->io, packet->buffer, sizeof(pcapng_nrb_t));
 
         if (err < 0) {
-                trace_set_err(libtrace, errno, "reading pcapng name resolution block");
+                trace_set_err(libtrace, TRACE_ERR_WANDIO_FAILED, "reading pcapng name resolution block");
                 return -1;
         }
 
@@ -681,7 +681,7 @@ static int pcapng_read_custom(libtrace_t *libtrace, libtrace_packet_t *packet,
         err = wandio_read(libtrace->io, packet->buffer, sizeof(pcapng_custom_t));
 
         if (err < 0) {
-                trace_set_err(libtrace, errno, "reading pcapng custom block");
+                trace_set_err(libtrace, TRACE_ERR_WANDIO_FAILED, "reading pcapng custom block");
                 return -1;
         }
 
@@ -739,7 +739,7 @@ static int pcapng_read_stats(libtrace_t *libtrace, libtrace_packet_t *packet,
         err = wandio_read(libtrace->io, packet->buffer, sizeof(pcapng_stats_t));
 
         if (err < 0) {
-                trace_set_err(libtrace, errno, "reading pcapng interface stats");
+                trace_set_err(libtrace, TRACE_ERR_WANDIO_FAILED, "reading pcapng interface stats");
                 return -1;
         }
 
@@ -860,7 +860,7 @@ static int pcapng_read_simple(libtrace_t *libtrace, libtrace_packet_t *packet,
         err = wandio_read(libtrace->io, packet->buffer, sizeof(pcapng_spkt_t));
 
         if (err < 0) {
-                trace_set_err(libtrace, errno, "reading pcapng simple packet");
+                trace_set_err(libtrace, TRACE_ERR_WANDIO_FAILED, "reading pcapng simple packet");
                 return -1;
         }
 
@@ -929,7 +929,7 @@ static int pcapng_read_enhanced(libtrace_t *libtrace, libtrace_packet_t *packet,
         err = wandio_read(libtrace->io, packet->buffer, sizeof(pcapng_epkt_t));
 
         if (err < 0) {
-                trace_set_err(libtrace, errno, "reading pcapng enhanced packet");
+                trace_set_err(libtrace, TRACE_ERR_WANDIO_FAILED, "reading pcapng enhanced packet");
                 return -1;
         }
 
@@ -1038,7 +1038,7 @@ static int pcapng_read_packet(libtrace_t *libtrace, libtrace_packet_t *packet)
 
                 err = wandio_peek(libtrace->io, &peeker, sizeof(peeker));
                 if (err < 0) {
-                        trace_set_err(libtrace, errno, "reading pcapng packet");
+                        trace_set_err(libtrace, TRACE_ERR_WANDIO_FAILED, "reading pcapng packet");
                         return -1;
                 }
 
@@ -1047,7 +1047,7 @@ static int pcapng_read_packet(libtrace_t *libtrace, libtrace_packet_t *packet)
                 }
 
                 if (err < (int)sizeof(struct pcapng_peeker)) {
-                        trace_set_err(libtrace, errno, "Incomplete pcapng block");
+                        trace_set_err(libtrace, TRACE_ERR_WANDIO_FAILED, "Incomplete pcapng block");
                         return -1;
                 }
 

--- a/lib/format_tsh.c
+++ b/lib/format_tsh.c
@@ -130,7 +130,7 @@ static int tsh_read_packet(libtrace_t *libtrace, libtrace_packet_t *packet) {
 	if ((numbytes=wandio_read(libtrace->io,
 					buffer2,
 					(size_t)sizeof(tsh_pkt_header_t))) == -1) {
-		trace_set_err(libtrace,errno,"read(%s)",
+		trace_set_err(libtrace,TRACE_ERR_WANDIO_FAILED,"read(%s)",
 				libtrace->uridata);
 		return -1;
 	}
@@ -140,7 +140,7 @@ static int tsh_read_packet(libtrace_t *libtrace, libtrace_packet_t *packet) {
 	}
 
         if (numbytes < (int)sizeof(tsh_pkt_header_t)) {
-                trace_set_err(libtrace, errno, "Incomplete TSH header");
+                trace_set_err(libtrace, TRACE_ERR_WANDIO_FAILED, "Incomplete TSH header");
                 return -1;
         }
 
@@ -151,7 +151,7 @@ static int tsh_read_packet(libtrace_t *libtrace, libtrace_packet_t *packet) {
 				buffer2,
 				(size_t)sizeof(libtrace_ip_t)+16))  /* 16 bytes of transport header */
 			!= sizeof(libtrace_ip_t)+16) {
-		trace_set_err(libtrace,errno,"read(%s)",
+		trace_set_err(libtrace,TRACE_ERR_WANDIO_FAILED,"read(%s)",
 				libtrace->uridata);
 		return -1;
 	}
@@ -166,7 +166,7 @@ static int tsh_read_packet(libtrace_t *libtrace, libtrace_packet_t *packet) {
 	if ((numbytes=wandio_read(libtrace->io,
 				buffer2,
 				16)) != 16) {
-		trace_set_err(libtrace,errno,"read(%s)",
+		trace_set_err(libtrace,TRACE_ERR_WANDIO_FAILED,"read(%s)",
 				libtrace->uridata);
 		return -1;
 	}

--- a/lib/libtrace.h.in
+++ b/lib/libtrace.h.in
@@ -304,7 +304,9 @@ enum {
 	/** RT communication breakdown */
 	TRACE_ERR_RT_FAILURE    = -10,
 	/** Compression format unsupported */
-	TRACE_ERR_UNSUPPORTED_COMPRESS 	= -11
+	TRACE_ERR_UNSUPPORTED_COMPRESS 	= -11,
+        /** Wandio has returned an error */
+        TRACE_ERR_WANDIO_FAILED = -12  
 };
 
 /** Enumeration of DLTs supported by libtrace 


### PR DESCRIPTION
Passing an errcode of 0 to trace_set_err triggers the assertion at
format_helper.c:290, making the error unrecoverable for the calling
code. This happens when the wandio layer encounters an error while
errno is still 0 (for example, an incomplete pcap packet).

To make the error recoverable, pass in TRACE_ERR_WANDIO_FAILED instead
of errno.