### PR TITLE
Initial support for ERF Provenance (TYPE_META) records

### DIFF
--- a/lib/erftypes.h
+++ b/lib/erftypes.h
@@ -161,10 +161,22 @@
 #define TYPE_RAW_LINK		24
 #endif
 
+/** Provenance Metadata Record */
+#ifndef ERF_TYPE_META
+#define ERF_TYPE_META   27
+#endif
+/* TODO: Endace has deprecated TYPE_* in favour of ERF_TYPE_*. New types do not have TYPE_* aliases. */
+#ifndef TYPE_META
+#define TYPE_META       ERF_TYPE_META
+#endif
+
 /** Padding record */
 #ifndef TYPE_PAD
 #define TYPE_PAD		48
 #endif
 
+#ifndef ERF_TYPE_MAX
+#define ERF_TYPE_MAX    TYPE_PAD
+#endif
 
 #endif /* _ERFTYPES_H_ */

--- a/lib/format_dag25.c
+++ b/lib/format_dag25.c
@@ -186,7 +186,9 @@ static int dag_get_padding(const libtrace_packet_t *packet)
 		dag_record_t *erfptr = (dag_record_t *)packet->header;
 		switch(erfptr->type) {
 			case TYPE_ETH:
+			case TYPE_COLOR_ETH:
 			case TYPE_DSM_COLOR_ETH:
+			case TYPE_COLOR_HASH_ETH:
 				return 2;
 			default: 		return 0;
 		}
@@ -1049,7 +1051,7 @@ static int dag_prepare_packet_stream(libtrace_t *libtrace,
 	/* Update the dropped packets counter */
 	/* No loss counter for DSM coloured records - have to use some
 	 * other API */
-	if (erfptr->type == TYPE_DSM_COLOR_ETH) {
+	if (erf_is_color_type(erfptr->type)) {
 		/* TODO */
 	} else {
 		/* Use the ERF loss counter */

--- a/lib/format_erf.c
+++ b/lib/format_erf.c
@@ -119,7 +119,6 @@ typedef struct erf_index_t {
 	uint64_t offset; 
 } erf_index_t;
 
-
 /* Ethernet packets have a 2 byte padding before the packet
  * so that the IP header is aligned on a 32 bit boundary.
  */
@@ -130,8 +129,10 @@ static int erf_get_padding(const libtrace_packet_t *packet)
                         packet->trace->format->type == TRACE_FORMAT_RAWERF) {
 		dag_record_t *erfptr = (dag_record_t *)packet->header;
 		switch((erfptr->type & 0x7f)) {
-			case TYPE_ETH: 		
+			case TYPE_ETH:
+			case TYPE_COLOR_ETH:
 			case TYPE_DSM_COLOR_ETH:
+			case TYPE_COLOR_HASH_ETH:
 				return 2;
 			default: 		return 0;
 		}
@@ -142,6 +143,21 @@ static int erf_get_padding(const libtrace_packet_t *packet)
 			default:		return 0;
 		}
 	}
+}
+
+int erf_is_color_type(uint8_t erf_type)
+{
+	switch(erf_type & 0x7f) {
+		case TYPE_COLOR_HDLC_POS:
+		case TYPE_DSM_COLOR_HDLC_POS:
+		case TYPE_COLOR_ETH:
+		case TYPE_DSM_COLOR_ETH:
+		case TYPE_COLOR_HASH_POS:
+		case TYPE_COLOR_HASH_ETH:
+			return 1;
+	}
+
+	return 0;
 }
 
 int erf_get_framing_length(const libtrace_packet_t *packet)
@@ -198,7 +214,7 @@ static int erf_probe_magic(io_t *io)
 		return 0;
 	}
 	/* Is this a proper typed packet */
-	if ((erf->type & 0x7f) > TYPE_AAL2) {
+	if ((erf->type & 0x7f) > ERF_TYPE_MAX) {
 		return 0;
 	}
 	/* We should put some more tests in here. */
@@ -462,7 +478,7 @@ static int erf_prepare_packet(libtrace_t *libtrace, libtrace_packet_t *packet,
 	}
 
 	/* Check for loss */
-	if ((erfptr->type & 0x7f) == TYPE_DSM_COLOR_ETH) {
+	if (erf_is_color_type(erfptr->type)) {
 		/* No idea how we get this yet */
 
 	} else if (erfptr->lctr) {
@@ -519,7 +535,7 @@ static int erf_read_packet(libtrace_t *libtrace, libtrace_packet_t *packet) {
 	}
 
 	/* Unknown/corrupt */
-	if ((((dag_record_t *)packet->buffer)->type & 0x7f) >= TYPE_RAW_LINK) {
+	if ((((dag_record_t *)packet->buffer)->type & 0x7f) > ERF_TYPE_MAX) {
 		trace_set_err(libtrace, TRACE_ERR_BAD_PACKET, 
 				"Corrupt or Unknown ERF type");
 		return -1;
@@ -756,21 +772,27 @@ int erf_get_capture_length(const libtrace_packet_t *packet) {
 int erf_get_wire_length(const libtrace_packet_t *packet) {
 	dag_record_t *erfptr = 0;
 	erfptr = (dag_record_t *)packet->header;
+
+	if ((erfptr->type & 0x7f) == TYPE_META)
+		return 0;
+
 	return ntohs(erfptr->wlen);
 }
 
 size_t erf_set_capture_length(libtrace_packet_t *packet, size_t size) {
 	dag_record_t *erfptr = 0;
 	assert(packet);
-	if(size  > trace_get_capture_length(packet)) {
+	erfptr = (dag_record_t *)packet->header;
+
+	if(size > trace_get_capture_length(packet) || (erfptr->type & 0x7f) == TYPE_META) {
 		/* Can't make a packet larger */
 		return trace_get_capture_length(packet);
 	}
+
 	/* Reset cached capture length - otherwise we will both return the
 	 * wrong value here and subsequent get_capture_length() calls will
 	 * return the wrong value. */
 	packet->capture_length = -1;
-	erfptr = (dag_record_t *)packet->header;
 	erfptr->rlen = htons(size + erf_get_framing_length(packet));
 	return trace_get_capture_length(packet);
 }

--- a/lib/format_erf.h
+++ b/lib/format_erf.h
@@ -52,5 +52,6 @@ uint64_t erf_get_erf_timestamp(const libtrace_packet_t *packet);
 int erf_get_capture_length(const libtrace_packet_t *packet);
 int erf_get_wire_length(const libtrace_packet_t *packet);
 size_t erf_set_capture_length(libtrace_packet_t *packet, size_t size);
+int erf_is_color_type(uint8_t erf_type);
 
 #endif

--- a/lib/format_pcap.c
+++ b/lib/format_pcap.c
@@ -497,6 +497,12 @@ static int pcap_write_packet(libtrace_out_t *libtrace,
 
 	link = trace_get_packet_buffer(packet,&linktype,&remaining);
 
+	/* Silently discard RT metadata packets and packets with an
+	 * unknown linktype. */
+	if (linktype == TRACE_TYPE_NONDATA || linktype == TRACE_TYPE_UNKNOWN || linktype == TRACE_TYPE_ERF_META) {
+		return 0;
+	}
+
 	/* We may have to convert this packet into a suitable PCAP packet */
 
 	/* If this packet cannot be converted to a pcap linktype then
@@ -580,9 +586,13 @@ static int pcapint_write_packet(libtrace_out_t *libtrace,
 		libtrace_packet_t *packet) 
 {
 	int err;
+	libtrace_linktype_t linktype = trace_get_link_type(packet);
 
-	if (trace_get_link_type(packet) == TRACE_TYPE_NONDATA)
+	/* Silently discard RT metadata packets and packets with an
+	 * unknown linktype. */
+	if (linktype == TRACE_TYPE_NONDATA || linktype == TRACE_TYPE_UNKNOWN || linktype == TRACE_TYPE_ERF_META) {
 		return 0;
+	}
 
 	if (!OUTPUT.trace.pcap) {
 		OUTPUT.trace.pcap = (pcap_t *)pcap_open_live(

--- a/lib/format_pcapfile.c
+++ b/lib/format_pcapfile.c
@@ -430,7 +430,7 @@ static int pcapfile_write_packet(libtrace_out_t *out,
 	
 	/* Silently discard RT metadata packets and packets with an
 	 * unknown linktype. */
-	if (linktype == TRACE_TYPE_NONDATA || linktype == TRACE_TYPE_UNKNOWN) {
+	if (linktype == TRACE_TYPE_NONDATA || linktype == TRACE_TYPE_UNKNOWN || linktype == TRACE_TYPE_ERF_META) {
 		return 0;
 	}
 

--- a/lib/libtrace.h.in
+++ b/lib/libtrace.h.in
@@ -366,7 +366,8 @@ typedef enum {
        TRACE_TYPE_PPP = 17,	     /**< PPP frames */
        TRACE_TYPE_METADATA = 18,     	/**< WDCAP-style meta-data */
        TRACE_TYPE_NONDATA = 19,		/**< Not a data packet */
-       TRACE_TYPE_OPENBSD_LOOP = 20	/**< OpenBSD loopback */
+       TRACE_TYPE_OPENBSD_LOOP = 20,	/**< OpenBSD loopback */
+       TRACE_TYPE_ERF_META = 21 /**< ERF Provenance metadata record */
 } libtrace_linktype_t;
 
 /** RT protocol base format identifiers.

--- a/lib/linktypes.c
+++ b/lib/linktypes.c
@@ -101,6 +101,8 @@ libtrace_dlt_t libtrace_to_pcap_dlt(libtrace_linktype_t type)
 		case TRACE_TYPE_DUCK:
 		/* Used for test traces within WAND */
 		case TRACE_TYPE_80211_PRISM: 	
+		/* Could use DLT_ERF, but would only really make sense with PCAP-NG */
+		case TRACE_TYPE_ERF_META:
 		/* Probably == PPP */
 		/* TODO: We haven't researched these yet */
 		case TRACE_TYPE_AAL5:
@@ -168,9 +170,12 @@ libtrace_linktype_t erf_type_to_libtrace(uint8_t erf)
 		case TYPE_ETH:		return TRACE_TYPE_ETH;
 		case TYPE_ATM:		return TRACE_TYPE_ATM;
 		case TYPE_AAL5:		return TRACE_TYPE_AAL5;
+		case TYPE_COLOR_ETH:return TRACE_TYPE_ETH;
 		case TYPE_DSM_COLOR_ETH:return TRACE_TYPE_ETH;
+		case TYPE_COLOR_HASH_ETH:return TRACE_TYPE_ETH;
 		case TYPE_IPV4:		return TRACE_TYPE_NONE;
 		case TYPE_IPV6:		return TRACE_TYPE_NONE;
+		case TYPE_META:		return TRACE_TYPE_ERF_META;
 	}
 	return ~0U;
 }
@@ -182,6 +187,7 @@ uint8_t libtrace_to_erf_type(libtrace_linktype_t linktype)
 		case TRACE_TYPE_ETH:	return TYPE_ETH;
 		case TRACE_TYPE_ATM:	return TYPE_ATM;
 		case TRACE_TYPE_AAL5:	return TYPE_AAL5;
+		case TRACE_TYPE_ERF_META: return TYPE_META;
 		
 		/* Not technically correct! Could be IPv6 packet 
 		 *

--- a/lib/protocols_l2.c
+++ b/lib/protocols_l2.c
@@ -481,6 +481,7 @@ DLLEXPORT void *trace_get_layer2(const libtrace_packet_t *packet,
 		case TRACE_TYPE_80211_RADIO:
 		case TRACE_TYPE_80211_PRISM:
 		case TRACE_TYPE_PFLOG:
+		case TRACE_TYPE_ERF_META:
 			break;
 		case TRACE_TYPE_UNKNOWN:
 			return NULL;
@@ -516,6 +517,7 @@ DLLEXPORT void *trace_get_layer2(const libtrace_packet_t *packet,
 				case TRACE_TYPE_80211_RADIO:
 				case TRACE_TYPE_80211_PRISM:
 				case TRACE_TYPE_PFLOG:
+				case TRACE_TYPE_ERF_META:
 					break;
 				case TRACE_TYPE_UNKNOWN:
 					return NULL;
@@ -582,6 +584,7 @@ DLLEXPORT void *trace_get_payload_from_layer2(void *link,
 		   */
 		case TRACE_TYPE_METADATA:
 		case TRACE_TYPE_NONDATA:
+		case TRACE_TYPE_ERF_META:
 		case TRACE_TYPE_UNKNOWN:
 			return NULL;
 
@@ -684,6 +687,7 @@ DLLEXPORT uint8_t *trace_get_source_mac(libtrace_packet_t *packet) {
                 case TRACE_TYPE_PPP:
 		case TRACE_TYPE_NONDATA:
 		case TRACE_TYPE_OPENBSD_LOOP:
+		case TRACE_TYPE_ERF_META:
 		case TRACE_TYPE_UNKNOWN:
                         return NULL;
 
@@ -733,6 +737,7 @@ DLLEXPORT uint8_t *trace_get_destination_mac(libtrace_packet_t *packet)
 		case TRACE_TYPE_PPP:	
 		case TRACE_TYPE_NONDATA:
 		case TRACE_TYPE_OPENBSD_LOOP:
+		case TRACE_TYPE_ERF_META:
 		case TRACE_TYPE_UNKNOWN:
                         /* No MAC address */
                         return NULL;

--- a/lib/protocols_pktmeta.c
+++ b/lib/protocols_pktmeta.c
@@ -137,6 +137,7 @@ DLLEXPORT void *trace_get_packet_meta(const libtrace_packet_t *packet,
 		case TRACE_TYPE_LINUX_SLL:
 		case TRACE_TYPE_80211_RADIO:
 		case TRACE_TYPE_80211_PRISM:
+		case TRACE_TYPE_ERF_META:
 			return pktbuf;
 		/* Non metadata packets */
 		case TRACE_TYPE_HDLC_POS:
@@ -210,6 +211,7 @@ DLLEXPORT void *trace_get_payload_from_meta(const void *meta,
 		case TRACE_TYPE_METADATA:
 		case TRACE_TYPE_NONDATA:
 		case TRACE_TYPE_OPENBSD_LOOP:
+		case TRACE_TYPE_ERF_META:
 		case TRACE_TYPE_UNKNOWN:
 			/* In this case, the pointer passed in does not point
 			 * to a metadata header and so we cannot get the

--- a/lib/trace.c
+++ b/lib/trace.c
@@ -1508,7 +1508,7 @@ DLLEXPORT int trace_apply_filter(libtrace_filter_t *filter,
 	 * through to the caller */
 	linktype = trace_get_link_type(packet);
 
-	if (linktype == TRACE_TYPE_NONDATA)
+	if (linktype == TRACE_TYPE_NONDATA || linktype == TRACE_TYPE_ERF_META)
 		return 1;
 
 	if (libtrace_to_pcap_dlt(linktype)==TRACE_DLT_ERROR) {


### PR DESCRIPTION
Initial support for ERF Provenance (TYPE_META) records, with some other minor cleanup. Fixes #59.

* Check for ERF_TYPE_MAX rather than some arbitrary type in ERF sanity checks. In Wireshark we recently completely removed these checks as there are only a few types before TYPE_PAD/ERF_TYPE_MAX, but leave them in for now.
* Add TRACE_TYPE_ERF_META for provenance record payload.
* Continue to use TRACE_RT_DATA_ERF as provenance is a valid ERF record. Note: this means that LIBTRACE_IS_META_PACKET() will currently return FALSE which may confuse some tools. Other places in the code also tend to check for TRACE_TYPE_NONDATA which isn't true here either.
* Return zero for wire length of provenance records.
* Don't allow snapping them (just return the same value).
* Skip provenance records in l2 parsers and trace_get_payload_from_meta().
* Return provenance payload for trace_get_packet_meta().
* Always match provenance records when applying filters.
* Silently discard ERF provenance records when writing PCAP. Doesn't include other formats for now, which tend to only check for TRACE_TYPE_NONDATA. 

Also add support for a couple of missing ERF_TYPE_COLOR_ETH variants.

Known issues:
* Accepted packet count includes provenance records, and they display in tracedump output as an unknown type. Other kinds of statistics and flow level statistics seem still to work correctly since the wire length is reported as 0.
* Tracereplay doesn't work, see #61.
* DAG transmit is somewhat broken, as provenance record containing traces pretty much always have extension headers, see #62.

More thought is probably needed on genericizing non-data linktype checks into something like a trace_linktype_is_nondata() vs the IS_LIBTRACE_META_PACKET check in trace_write_packet() which is currently false for provenance records vs more generic skipping of non-writeable types for each format. I went with the simple approach for now.

