### PR TITLE
Adjust compression level manpage to actual options in code

### DIFF
--- a/tools/tracesplit/tracesplit.1
+++ b/tools/tracesplit/tracesplit.1
@@ -68,7 +68,7 @@ more processing power to compress.
 .TP
 \fB-Z\fR compression-method
 Compress the data using the specified compression algorithm. Accepted methods
-are "gzip", "bzip2", "lzo", "xz" or "none". Default value is none unless a 
+are "gz", "bz", "lzo", "xz" or "no". Default value is none unless a 
 compression level is specified, in which case gzip will be used.
 
 .SH EXAMPLES


### PR DESCRIPTION
The man page mentions the wrong options for the -Z compression parameter.
This change also has to be applied to other manpages like tracemerge.

Alternatively the code checking the compression method could be changed to support the options mentioned in the manpages.
https://github.com/LibtraceTeam/libtrace/blob/master/tools/tracesplit/tracesplit.c#L441