### PR TITLE
Fix for building without WANDDER

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -488,7 +488,6 @@ if test "$have_numa" = 1; then
 	AC_DEFINE(HAVE_LIBNUMA, 1, [Set to 1 if libnuma is supported])
 	with_numa=yes
 else
-	AC_DEFINE(HAVE_LIBNUMA, 0, [Set to 1 if libnuma is supported])
 	with_numa=no
 fi
 
@@ -497,7 +496,6 @@ if test "$have_wandder" = 1; then
         AC_DEFINE(HAVE_WANDDER, 1, [Set to 1 if libwandder is available])
         wandder_avail=yes
 else
-        AC_DEFINE(HAVE_WANDDER, 0, [Set to 1 if libwandder is available])
         wandder_avail=no
 fi
 
@@ -548,7 +546,6 @@ if test "$have_clock_gettime" = 1; then
 	AC_DEFINE(HAVE_CLOCK_GETTIME, 1, [Set to 1 if clock_gettime is supported])
 	with_clock_gettime=yes
 else
-	AC_DEFINE(HAVE_CLOCK_GETTIME, 0, [Set to 1 if clock_gettime is supported])
 	with_clock_gettime=no
 fi
 

--- a/lib/format_dpdk.c
+++ b/lib/format_dpdk.c
@@ -56,7 +56,7 @@
 #include <string.h>
 #include <math.h>
 
-#if HAVE_LIBNUMA
+#ifdef HAVE_LIBNUMA
 #include <numa.h>
 #endif
 
@@ -459,7 +459,7 @@ static inline int dpdk_init_environment(char * uridata, struct dpdk_format_data_
 		return -1;
 	}
 
-#if HAVE_LIBNUMA
+#ifdef HAVE_LIBNUMA
 	format_data->nic_numa_node = pci_to_numa(&use_addr);
 	if (my_cpu < 0) {
 #if DEBUG
@@ -890,7 +890,7 @@ static int dpdk_reserve_lcore(bool real, int socket) {
 	 * in this case physical cores on the system will not exist so we don't bind
 	 * these to any particular physical core */
 	if (real) {
-#if HAVE_LIBNUMA
+#ifdef HAVE_LIBNUMA
 		for (i = 0; i < RTE_MAX_LCORE; ++i) {
 			if (!rte_lcore_is_enabled(i) && numa_node_of_cpu(i) == socket) {
 				new_id = i;

--- a/libpacketdump/Makefile.am
+++ b/libpacketdump/Makefile.am
@@ -61,7 +61,9 @@ BIN_PROTOCOLS+=link_15.la
 TXT_PROTOCOLS+=link_17.protocol
 
 # 22: ETSI LI
+if HAVE_WANDDER
 BIN_PROTOCOLS+=link_22.la
+endif
 
 # Decoders for various ethertypes (in decimal)
 # IPv4
@@ -137,7 +139,9 @@ link_9_la_LDFLAGS=$(modflags)
 link_10_la_LDFLAGS=$(modflags)
 link_11_la_LDFLAGS=$(modflags)
 link_15_la_LDFLAGS=$(modflags) 
+if HAVE_WANDDER
 link_22_la_LDFLAGS=$(modflags) 
+endif
 eth_0_la_LDFLAGS=$(modflags)
 eth_2048_la_LDFLAGS=$(modflags)
 eth_2054_la_LDFLAGS=$(modflags)


### PR DESCRIPTION
The code was accidentally checking ifdef, but HAVE_WANDDER was
set to 0. I've fixed this by not setting to 0, like we do elsewhere.
I've also updated HAVE_LIBNUMA to use the same style of check.

Not sure if this is the correct thing to do for tracepktdump? Do we still need to handle the protocol type somehow?