### PR TITLE
Replace AC_CHECK_FUNCS with AC_CHECK_DECLS

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -86,10 +86,6 @@ AC_CONFIG_LIBOBJ_DIR(lib)
 AC_FUNC_MALLOC
 AC_FUNC_REALLOC
 
-# *BSD doesn't have strndup. Currently provide our own.
-AC_REPLACE_FUNCS(strndup)
-
-
 # Checks for typedefs, structures, and compiler characteristics.
 AC_C_CONST
 AC_C_INLINE
@@ -125,7 +121,7 @@ AC_PROG_LIBTOOL
 AC_PROG_GCC_TRADITIONAL
 
 # Fail if any of these functions are missing
-AC_CHECK_FUNCS(socket strdup strlcpy strcasecmp strncasecmp snprintf vsnprintf recvmmsg)
+AC_CHECK_DECLS([socket, strdup, strlcpy, strcasecmp, strncasecmp, snprintf, vsnprintf, recvmmsg, strndup])
 
 AC_CHECK_SIZEOF([long int])
 

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -77,7 +77,8 @@ libtrace_la_SOURCES = trace.c trace_parallel.c common.h \
 		data-struct/linked_list.c hash_toeplitz.c combiner_ordered.c \
                 data-struct/buckets.c data-struct/simple_circular_buffer.c \
 		combiner_sorted.c combiner_unordered.c \
-		pthread_spinlock.c pthread_spinlock.h
+		pthread_spinlock.c pthread_spinlock.h \
+		strndup.c
 
 if DAG2_4
 nodist_libtrace_la_SOURCES = dagopts.c dagapi.c

--- a/lib/libtrace_int.h
+++ b/lib/libtrace_int.h
@@ -98,11 +98,11 @@ extern "C" {
 #  include <zlib.h>
 #endif
 
-#ifndef HAVE_STRNDUP
+#if !HAVE_DECL_STRNDUP
 char *strndup(const char *s, size_t size);
 #endif
 
-#ifndef HAVE_STRNCASECMP
+#if !HAVE_DECL_STRNCASECMP
 # ifndef HAVE__STRNICMP
 /** A local implementation of strncasecmp (as some systems do not have it) */
 int strncasecmp(const char *str1, const char *str2, size_t n);
@@ -111,7 +111,7 @@ int strncasecmp(const char *str1, const char *str2, size_t n);
 # endif
 #endif
 
-#ifndef HAVE_SNPRINTF
+#if !HAVE_DECL_SNPRINTF
 # ifndef HAVE_SPRINTF_S
 /** A local implementation of snprintf (as some systems do not have it) */
 int snprintf(char *str, size_t size, const char *format, ...);

--- a/lib/strndup.c
+++ b/lib/strndup.c
@@ -23,7 +23,8 @@
  *
  *
  */
-#ifndef HAVE_STRNDUP
+#include "config.h"
+#if !HAVE_DECL_STRNDUP
 
 #include <stdlib.h>
 #include <errno.h>


### PR DESCRIPTION
It seems that `AC_CHECK_FUNCS` does not correctly detect when these "functions" are implemented as macros. (I've seen this happening on macOS, and Ubuntu 16.04 with `snprintf` and `strndup` respectively.) Replacing `AC_CHECK_FUNCS` (and the similar `AC_REPLACE_FUNCS`) with `AC_CHECK_DECLS` seems to solve this problem, though I don't have access to any systems that do not have these functions to be sure that it correctly detects them as missing.

Also, I'm not sure that the various `#if !HAVE_DECL_*` checks in `libtrace_int.h`are actually of any use (except for `HAVE_DECL_STRNDUP` which correctly declares the replacement we provide in `strndup.c`).

In the long term we may want to rework this so that we simply require these functions and error out at configure time if they are not available. Or even better, just drop the checks altogether?