### PR TITLE
Pcapng -  fix buffer overrun - hardening and refactoring

### DIFF
--- a/lib/format_pcapng.c
+++ b/lib/format_pcapng.c
@@ -729,7 +729,7 @@ static int pcapng_read_custom(libtrace_t *libtrace, libtrace_packet_t *packet,
                         byteswap32(hdr->blocktype) == PCAPNG_CUSTOM_NONCOPY_TYPE);
                 to_read = byteswap32(hdr->blocklen) - sizeof(pcapng_custom_t);
         } else {
-                assert(hdr->blocktype == PCAPNG_NAME_RESOLUTION_TYPE ||
+                assert(hdr->blocktype == PCAPNG_CUSTOM_TYPE ||
                         hdr->blocktype == PCAPNG_CUSTOM_NONCOPY_TYPE);
                 to_read = hdr->blocklen - sizeof(pcapng_custom_t);
         }
@@ -826,7 +826,7 @@ static int pcapng_read_stats(libtrace_t *libtrace, libtrace_packet_t *packet,
                                 &optcode, &optlen, (pcapng_hdr_t *) packet->buffer);
                 if (optval == NULL) {
                         trace_set_err(libtrace, TRACE_ERR_BAD_PACKET,
-                                "Failed to read options for pcapng enhanced packet");
+                                "Failed to read options for pcapng interface stats");
                         return -1;
                 }
 
@@ -1077,6 +1077,7 @@ static int pcapng_read_packet(libtrace_t *libtrace, libtrace_packet_t *packet)
                         return -1;
                 }
 
+                // Warning: the byteorder might not be set yet, the section header sets this
                 if (DATA(libtrace)->byteswapped) {
                         btype = byteswap32(peeker.blocktype);
                         to_read = byteswap32(peeker.blocklen);

--- a/lib/format_pcapng.c
+++ b/lib/format_pcapng.c
@@ -453,7 +453,7 @@ static int pcapng_read_section(libtrace_t *libtrace,
                 return 0;
         }
 
-        if (err < (int)(sizeof(sechdr))) {
+        if (err < (int)(sizeof(pcapng_sec_t))) {
                 trace_set_err(libtrace, TRACE_ERR_BAD_PACKET,
                         "Incomplete pcapng section header block");
                 return -1;
@@ -528,7 +528,7 @@ static int pcapng_read_interface(libtrace_t *libtrace,
                 return 0;
         }
 
-        if (err < (int)sizeof(inthdr)) {
+        if (err < (int)sizeof(pcapng_int_t)) {
                 trace_set_err(libtrace, TRACE_ERR_BAD_PACKET,
                         "Incomplete pcapng interface header block");
                 return -1;

--- a/lib/format_pcapng.c
+++ b/lib/format_pcapng.c
@@ -340,35 +340,6 @@ static char *pcapng_parse_next_option(libtrace_t *libtrace, char **pktbuf,
         return optval;
 }
 
-static inline int skip_block(libtrace_t *libtrace, uint32_t toread) {
-        int err;
-
-        while (toread > 0) {
-                char buf[4096];
-                int nextread;
-
-                if (toread < 4096) {
-                        nextread = toread;
-                } else {
-                        nextread = 4096;
-                }
-
-                err = wandio_read(libtrace->io, buf, nextread);
-                if (err < 0) {
-                        trace_set_err(libtrace, TRACE_ERR_WANDIO_FAILED,
-                                "Reading section header options");
-                        return -1;
-                }
-                if (err == 0) {
-                        return 0;
-                }
-                toread -= err;
-        }
-
-        return 1;
-
-}
-
 static inline int pcapng_read_body(libtrace_t *libtrace, char *body,
                 uint32_t to_read) {
 
@@ -377,7 +348,7 @@ static inline int pcapng_read_body(libtrace_t *libtrace, char *body,
         err = wandio_read(libtrace->io, body, to_read);
         if (err < 0) {
                 trace_set_err(libtrace, TRACE_ERR_WANDIO_FAILED,
-                        "Failed to read pcapng interface options");
+                        "Failed reading pcapng block");
                 return err;
         }
 
@@ -387,7 +358,7 @@ static inline int pcapng_read_body(libtrace_t *libtrace, char *body,
 
         if (err < (int)to_read) {
                 trace_set_err(libtrace, TRACE_ERR_BAD_PACKET,
-                        "Incomplete pcapng interface header block");
+                        "Incomplete pcapng block");
                 return -1;
         }
 
@@ -515,7 +486,7 @@ static int pcapng_read_section(libtrace_t *libtrace,
 
         /* Read all of the options etc. -- we don't need them for now, but
          * we have to skip forward to the next useful header. */
-        bodyptr = packet->buffer + sizeof(pcapng_sec_t);
+        bodyptr = (char *) packet->buffer + sizeof(pcapng_sec_t);
         err = pcapng_read_body(libtrace, bodyptr, to_read);
         if (err <= 0) {
                 return err;
@@ -531,29 +502,15 @@ static int pcapng_read_section(libtrace_t *libtrace,
 }
 
 static int pcapng_read_interface(libtrace_t *libtrace,
-                libtrace_packet_t *packet, uint32_t flags) {
+                libtrace_packet_t *packet, uint32_t blocklen, uint32_t flags) {
 
         pcapng_int_t *inthdr;
-        int err;
-        uint32_t to_read;
         pcapng_interface_t *newint;
         uint16_t optcode, optlen;
         char *optval = NULL;
         char *bodyptr = NULL;
 
-        err = wandio_read(libtrace->io, packet->buffer, sizeof(pcapng_int_t));
-
-        if (err < 0) {
-                trace_set_err(libtrace, TRACE_ERR_WANDIO_FAILED,
-                        "Reading pcapng interface header block");
-                return -1;
-        }
-
-        if (err == 0) {
-                return 0;
-        }
-
-        if (err < (int)sizeof(pcapng_int_t)) {
+        if (blocklen < sizeof(pcapng_int_t) + 4) {
                 trace_set_err(libtrace, TRACE_ERR_BAD_PACKET,
                         "Incomplete pcapng interface header block");
                 return -1;
@@ -576,12 +533,10 @@ static int pcapng_read_interface(libtrace_t *libtrace,
                 assert(byteswap32(inthdr->blocktype) == PCAPNG_INTERFACE_TYPE);
                 newint->snaplen = byteswap32(inthdr->snaplen);
                 newint->linktype = byteswap16(inthdr->linktype);
-                to_read = byteswap32(inthdr->blocklen) - sizeof(pcapng_int_t);
         } else {
                 assert(inthdr->blocktype == PCAPNG_INTERFACE_TYPE);
                 newint->snaplen = inthdr->snaplen;
                 newint->linktype = inthdr->linktype;
-                to_read = inthdr->blocklen - sizeof(pcapng_int_t);
         }
 
         if (DATA(libtrace)->nextintid == DATA(libtrace)->allocatedinterfaces) {
@@ -596,11 +551,7 @@ static int pcapng_read_interface(libtrace_t *libtrace,
         DATA(libtrace)->interfaces[newint->id] = newint;
         DATA(libtrace)->nextintid += 1;
 
-        bodyptr = packet->buffer + sizeof(pcapng_int_t);
-        err = pcapng_read_body(libtrace, bodyptr, to_read);
-        if (err <= 0) {
-                return err;
-        }
+        bodyptr = (char *) packet->buffer + sizeof(pcapng_int_t);
 
         packet->type = TRACE_RT_PCAPNG_META;
 
@@ -631,34 +582,20 @@ static int pcapng_read_interface(libtrace_t *libtrace,
 
         } while (optcode != 0);
 
-        return 1;
+        return (int) blocklen;
 
 }
 
 static int pcapng_read_nrb(libtrace_t *libtrace, libtrace_packet_t *packet,
-                uint32_t flags) {
+                uint32_t blocklen, uint32_t flags) {
 
         /* Just read the NR records and pass them off to the caller. If
          * they want to do anything with them, they can parse the records
          * themselves.
          */
         pcapng_nrb_t *hdr = NULL;
-        int err;
-        uint32_t to_read;
-        char *bodyptr;
 
-        err = wandio_read(libtrace->io, packet->buffer, sizeof(pcapng_nrb_t));
-
-        if (err < 0) {
-                trace_set_err(libtrace, TRACE_ERR_WANDIO_FAILED, "reading pcapng name resolution block");
-                return -1;
-        }
-
-        if (err == 0) {
-                return 0;
-        }
-
-        if (err < (int)sizeof(pcapng_nrb_t)) {
+        if (blocklen < sizeof(pcapng_nrb_t) + 4) {
                 trace_set_err(libtrace, TRACE_ERR_BAD_PACKET,
                                 "Incomplete pcapng name resolution block");
                 return -1;
@@ -669,16 +606,8 @@ static int pcapng_read_nrb(libtrace_t *libtrace, libtrace_packet_t *packet,
         /* Read the rest of the packet into the buffer */
         if (DATA(libtrace)->byteswapped) {
                 assert(byteswap32(hdr->blocktype) == PCAPNG_NAME_RESOLUTION_TYPE);
-                to_read = byteswap32(hdr->blocklen) - sizeof(pcapng_nrb_t);
         } else {
                 assert(hdr->blocktype == PCAPNG_NAME_RESOLUTION_TYPE);
-                to_read = hdr->blocklen - sizeof(pcapng_nrb_t);
-        }
-
-        bodyptr = packet->buffer + sizeof(pcapng_nrb_t);
-        err = pcapng_read_body(libtrace, bodyptr, to_read);
-        if (err <= 0) {
-                return err;
         }
 
         packet->type = TRACE_RT_PCAPNG_META;
@@ -687,34 +616,20 @@ static int pcapng_read_nrb(libtrace_t *libtrace, libtrace_packet_t *packet,
                 return -1;
         }
 
-        return sizeof(pcapng_nrb_t) + to_read;
+        return (int) blocklen;
 
 }
 
 static int pcapng_read_custom(libtrace_t *libtrace, libtrace_packet_t *packet,
-                uint32_t flags) {
+                uint32_t blocklen, uint32_t flags) {
 
         /* Just read the custom records and pass them off to the caller. If
          * they want to do anything with them, they can parse the records
          * themselves.
          */
         pcapng_custom_t *hdr = NULL;
-        int err;
-        uint32_t to_read;
-        char *bodyptr;
 
-        err = wandio_read(libtrace->io, packet->buffer, sizeof(pcapng_custom_t));
-
-        if (err < 0) {
-                trace_set_err(libtrace, TRACE_ERR_WANDIO_FAILED, "reading pcapng custom block");
-                return -1;
-        }
-
-        if (err == 0) {
-                return 0;
-        }
-
-        if (err < (int)sizeof(pcapng_custom_t)) {
+        if (blocklen < sizeof(pcapng_custom_t) + 4) {
                 trace_set_err(libtrace, TRACE_ERR_BAD_PACKET,
                                 "Incomplete pcapng custom block");
                 return -1;
@@ -726,17 +641,9 @@ static int pcapng_read_custom(libtrace_t *libtrace, libtrace_packet_t *packet,
         if (DATA(libtrace)->byteswapped) {
                 assert(byteswap32(hdr->blocktype) == PCAPNG_CUSTOM_TYPE ||
                         byteswap32(hdr->blocktype) == PCAPNG_CUSTOM_NONCOPY_TYPE);
-                to_read = byteswap32(hdr->blocklen) - sizeof(pcapng_custom_t);
         } else {
                 assert(hdr->blocktype == PCAPNG_CUSTOM_TYPE ||
                         hdr->blocktype == PCAPNG_CUSTOM_NONCOPY_TYPE);
-                to_read = hdr->blocklen - sizeof(pcapng_custom_t);
-        }
-
-        bodyptr = packet->buffer + sizeof(pcapng_custom_t);
-        err = pcapng_read_body(libtrace, bodyptr, to_read);
-        if (err <= 0) {
-                return err;
         }
 
         packet->type = TRACE_RT_PCAPNG_META;
@@ -745,15 +652,13 @@ static int pcapng_read_custom(libtrace_t *libtrace, libtrace_packet_t *packet,
                 return -1;
         }
 
-        return sizeof(pcapng_custom_t) + to_read;
+        return (int) blocklen;
 
 }
 
 static int pcapng_read_stats(libtrace_t *libtrace, libtrace_packet_t *packet,
-                uint32_t flags) {
+                uint32_t blocklen, uint32_t flags) {
         pcapng_stats_t *hdr = NULL;
-        int err;
-        uint32_t to_read;
         uint32_t ifaceid;
         uint64_t timestamp;
         pcapng_interface_t *interface;
@@ -761,18 +666,7 @@ static int pcapng_read_stats(libtrace_t *libtrace, libtrace_packet_t *packet,
         char *optval;
         char *bodyptr;
 
-        err = wandio_read(libtrace->io, packet->buffer, sizeof(pcapng_stats_t));
-
-        if (err < 0) {
-                trace_set_err(libtrace, TRACE_ERR_WANDIO_FAILED, "reading pcapng interface stats");
-                return -1;
-        }
-
-        if (err == 0) {
-                return 0;
-        }
-
-        if (err < (int)sizeof(pcapng_stats_t)) {
+        if (blocklen < sizeof(pcapng_stats_t) + 4) {
                 trace_set_err(libtrace, TRACE_ERR_BAD_PACKET,
                                 "Incomplete pcapng interface stats header");
                 return -1;
@@ -783,21 +677,13 @@ static int pcapng_read_stats(libtrace_t *libtrace, libtrace_packet_t *packet,
         /* Read the rest of the packet into the buffer */
         if (DATA(libtrace)->byteswapped) {
                 assert(byteswap32(hdr->blocktype) == PCAPNG_INTERFACE_STATS_TYPE);
-                to_read = byteswap32(hdr->blocklen) - sizeof(pcapng_stats_t);
                 ifaceid = byteswap32(hdr->interfaceid);
                 timestamp = ((uint64_t)(byteswap32(hdr->timestamp_high)) << 32) + byteswap32(hdr->timestamp_low);
         } else {
                 assert(hdr->blocktype == PCAPNG_INTERFACE_STATS_TYPE);
-                to_read = hdr->blocklen - sizeof(pcapng_stats_t);
                 ifaceid = hdr->interfaceid;
                 timestamp = ((uint64_t)(hdr->timestamp_high) << 32) +
                                 hdr->timestamp_low;
-        }
-
-        bodyptr = packet->buffer + sizeof(pcapng_stats_t);
-        err = pcapng_read_body(libtrace, bodyptr, to_read);
-        if (err <= 0) {
-                return err;
         }
 
         /* Set packet type based on interface linktype */
@@ -814,7 +700,7 @@ static int pcapng_read_stats(libtrace_t *libtrace, libtrace_packet_t *packet,
         }
 
         if (timestamp < interface->laststats) {
-                return sizeof(pcapng_stats_t) + to_read;
+                return (int) blocklen;
         }
 
         /* All of the stats are stored as options */
@@ -868,32 +754,18 @@ static int pcapng_read_stats(libtrace_t *libtrace, libtrace_packet_t *packet,
         } while (optcode != 0);
         interface->laststats = timestamp;
 
-        return sizeof(pcapng_stats_t) + to_read;
+        return (int) blocklen;
 
 }
 
 static int pcapng_read_simple(libtrace_t *libtrace, libtrace_packet_t *packet,
-                uint32_t flags) {
+                uint32_t blocklen, uint32_t flags) {
 
-        int err;
-        uint32_t to_read;
         uint32_t caplen;
         pcapng_spkt_t *hdr = NULL;
         pcapng_interface_t *interface;
-        char *bodyptr;
 
-        err = wandio_read(libtrace->io, packet->buffer, sizeof(pcapng_spkt_t));
-
-        if (err < 0) {
-                trace_set_err(libtrace, TRACE_ERR_WANDIO_FAILED, "reading pcapng simple packet");
-                return -1;
-        }
-
-        if (err == 0) {
-                return 0;
-        }
-
-        if (err < (int)sizeof(pcapng_spkt_t)) {
+        if (blocklen < sizeof(pcapng_spkt_t) + 4) {
                 trace_set_err(libtrace, TRACE_ERR_BAD_PACKET,
                                 "Incomplete pcapng simple packet header");
                 return -1;
@@ -904,18 +776,12 @@ static int pcapng_read_simple(libtrace_t *libtrace, libtrace_packet_t *packet,
         /* Read the rest of the packet into the buffer */
         if (DATA(libtrace)->byteswapped) {
                 assert(byteswap32(hdr->blocktype) == PCAPNG_SIMPLE_PACKET_TYPE);
-                to_read = byteswap32(hdr->blocklen) - sizeof(pcapng_spkt_t);
-                caplen = to_read - 4;   /* account for trailing length field */
+                caplen = byteswap32(hdr->blocklen) - sizeof(pcapng_spkt_t) - 4;
+                         /* account for trailing length field */
         } else {
                 assert(hdr->blocktype == PCAPNG_SIMPLE_PACKET_TYPE);
-                to_read = hdr->blocklen - sizeof(pcapng_spkt_t);
-                caplen = to_read - 4; /* account for trailing length field */
-        }
-
-        bodyptr = packet->buffer + sizeof(pcapng_spkt_t);
-        err = pcapng_read_body(libtrace, bodyptr, to_read);
-        if (err <= 0) {
-                return err;
+                caplen = hdr->blocklen - sizeof(pcapng_spkt_t) - 4;
+                         /* account for trailing length field */
         }
 
         /* Set packet type based on interface linktype.
@@ -935,15 +801,13 @@ static int pcapng_read_simple(libtrace_t *libtrace, libtrace_packet_t *packet,
                         packet->type, flags)) {
                 return -1;
         }
-        return sizeof(pcapng_spkt_t) + to_read;
+        return (int) blocklen;
 
 }
 
 static int pcapng_read_enhanced(libtrace_t *libtrace, libtrace_packet_t *packet,
-                uint32_t flags) {
+                uint32_t blocklen, uint32_t flags) {
         pcapng_epkt_t *hdr = NULL;
-        int err;
-        uint32_t to_read;
         uint32_t caplen;
         uint32_t ifaceid;
         pcapng_interface_t *interface;
@@ -951,18 +815,7 @@ static int pcapng_read_enhanced(libtrace_t *libtrace, libtrace_packet_t *packet,
         char *optval;
         char *bodyptr;
 
-        err = wandio_read(libtrace->io, packet->buffer, sizeof(pcapng_epkt_t));
-
-        if (err < 0) {
-                trace_set_err(libtrace, TRACE_ERR_WANDIO_FAILED, "reading pcapng enhanced packet");
-                return -1;
-        }
-
-        if (err == 0) {
-                return 0;
-        }
-
-        if (err < (int)sizeof(pcapng_epkt_t)) {
+        if (blocklen < (int)sizeof(pcapng_epkt_t) + 4) {
                 trace_set_err(libtrace, TRACE_ERR_BAD_PACKET,
                                 "Incomplete pcapng enhanced packet header");
                 return -1;
@@ -974,20 +827,14 @@ static int pcapng_read_enhanced(libtrace_t *libtrace, libtrace_packet_t *packet,
         if (DATA(libtrace)->byteswapped) {
                 assert(byteswap32(hdr->blocktype) == PCAPNG_ENHANCED_PACKET_TYPE);
                 caplen = byteswap32(hdr->caplen);
-                to_read = byteswap32(hdr->blocklen) - sizeof(pcapng_epkt_t);
                 ifaceid = byteswap32(hdr->interfaceid);
         } else {
                 assert(hdr->blocktype == PCAPNG_ENHANCED_PACKET_TYPE);
                 caplen = hdr->caplen;
-                to_read = hdr->blocklen - sizeof(pcapng_epkt_t);
                 ifaceid = hdr->interfaceid;
         }
 
-        bodyptr = packet->buffer + sizeof(pcapng_epkt_t);
-        err = pcapng_read_body(libtrace, bodyptr, to_read);
-        if (err <= 0) {
-                return err;
-        }
+        bodyptr = (char *) packet->buffer + sizeof(pcapng_epkt_t);
 
         /* Set packet type based on interface linktype */
         interface = lookup_interface(libtrace, ifaceid);
@@ -1008,9 +855,15 @@ static int pcapng_read_enhanced(libtrace_t *libtrace, libtrace_packet_t *packet,
 
         /* Make sure to parse any useful options */
         if ((caplen % 4) == 0) {
-                bodyptr = packet->payload + caplen;
+                bodyptr = (char *) packet->payload + caplen;
         } else {
-                bodyptr = packet->payload + caplen + (4 - (caplen % 4));
+                bodyptr = (char *) packet->payload + caplen + (4 - (caplen % 4));
+        }
+        // Check the packet caplen actually fits within the block we read
+        if ((char *) packet->buffer + blocklen < bodyptr + 4) {
+                trace_set_err(libtrace, TRACE_ERR_BAD_PACKET,
+                                "Incomplete pcapng enhanced packet header");
+                return -1;
         }
 
         do {
@@ -1032,7 +885,7 @@ static int pcapng_read_enhanced(libtrace_t *libtrace, libtrace_packet_t *packet,
                 }
 
         } while (optcode != 0);
-        return sizeof(pcapng_epkt_t) + to_read;
+        return (int) blocklen;
 
 }
 
@@ -1092,6 +945,19 @@ static int pcapng_read_packet(libtrace_t *libtrace, libtrace_packet_t *packet)
                                       "Oversized pcapng block found, is the trace corrupted?");
                         return -1;
                 }
+                if (btype != PCAPNG_SECTION_TYPE) {
+                        // Read the entire block, unless it is a section as our byte ordering has
+                        // not been set yet.
+                        err = pcapng_read_body(libtrace, packet->buffer, to_read);
+                        if (err <= 0) {
+                                return err;
+                        }
+                        if (*((uint32_t *)((char *)packet->buffer+to_read-4)) != peeker.blocklen) {
+                                trace_set_err(libtrace, TRACE_ERR_BAD_PACKET,
+                                              "Mismatched pcapng block sizes found, trace is invalid.");
+                                return -1;
+                        }
+                }
 
                 switch (btype) {
                         /* Section Header */
@@ -1102,35 +968,35 @@ static int pcapng_read_packet(libtrace_t *libtrace, libtrace_packet_t *packet)
 
                         /* Interface Header */
                         case PCAPNG_INTERFACE_TYPE:
-                                err = pcapng_read_interface(libtrace, packet, flags);
+                                err = pcapng_read_interface(libtrace, packet, to_read, flags);
                                 gotpacket = 1;
                                 break;
 
 
                         case PCAPNG_ENHANCED_PACKET_TYPE:
                                 err = pcapng_read_enhanced(libtrace, packet,
-                                                flags);
+                                                to_read, flags);
                                 gotpacket = 1;
                                 break;
 
                         case PCAPNG_SIMPLE_PACKET_TYPE:
-                                err = pcapng_read_simple(libtrace, packet, flags);
+                                err = pcapng_read_simple(libtrace, packet, to_read, flags);
                                 gotpacket = 1;
                                 break;
 
                         case PCAPNG_INTERFACE_STATS_TYPE:
-                                err = pcapng_read_stats(libtrace, packet, flags);
+                                err = pcapng_read_stats(libtrace, packet, to_read, flags);
                                 gotpacket = 1;
                                 break;
 
                         case PCAPNG_NAME_RESOLUTION_TYPE:
-                                err = pcapng_read_nrb(libtrace, packet, flags);
+                                err = pcapng_read_nrb(libtrace, packet, to_read, flags);
                                 gotpacket = 1;
                                 break;
 
                         case PCAPNG_CUSTOM_TYPE:
                         case PCAPNG_CUSTOM_NONCOPY_TYPE:
-                                err = pcapng_read_custom(libtrace, packet, flags);
+                                err = pcapng_read_custom(libtrace, packet, to_read, flags);
                                 gotpacket = 1;
                                 break;
 
@@ -1140,7 +1006,6 @@ static int pcapng_read_packet(libtrace_t *libtrace, libtrace_packet_t *packet)
 
                         /* Everything else -- don't care, skip it */
                         default:
-                                err = skip_block(libtrace, to_read);
                                 break;
                 }
         }

--- a/lib/format_pcapng.c
+++ b/lib/format_pcapng.c
@@ -590,8 +590,7 @@ static int pcapng_read_interface(libtrace_t *libtrace,
                         DATA(libtrace)->interfaces,
                         DATA(libtrace)->allocatedinterfaces * sizeof(
                                 pcapng_interface_t *));
-
-                /* Could memset the new memory to zero, if required */
+                memset(&DATA(libtrace)->interfaces[DATA(libtrace)->nextintid], 0, sizeof(void *) * 10);
         }
 
         DATA(libtrace)->interfaces[newint->id] = newint;


### PR DESCRIPTION
Fixes a serious buffer overrun in pcapng option parsing (c171463).

I fixed and number of other minor issues and refactored out all duplicated reads to just one.

e9da777 is quite a big commit and refactors out a lot of the reads in the code, it also
contains some additional hardening but is less important than the other patches in this set.

I've tested this with the libtrace 100_packets.pcapng and complex.pcapng examples and some from wireshark's wiki and it seems to be working correctly.