### PR TITLE
Merge ring buffer management fixes

### DIFF
--- a/lib/format_linux_common.c
+++ b/lib/format_linux_common.c
@@ -231,13 +231,17 @@ void linuxcommon_close_input_stream(libtrace_t *libtrace,
 	if (stream->fd != -1)
 		close(stream->fd);
 	stream->fd = -1;
-	if (stream->rx_ring != MAP_FAILED)
-		munmap(stream->rx_ring,
-		       stream->req.tp_block_size *
-		       stream->req.tp_block_nr);
-	stream->rx_ring = MAP_FAILED;
-	stream->rxring_offset = 0;
 	FORMAT_DATA->dev_stats.if_name[0] = 0;
+
+        /* Don't munmap the rx_ring here -- keep it around as long as
+         * possible to ensure that any packets that the user is still
+         * holding references to remain valid.
+         *
+         * Don't worry, linuxring will munmap the rx_ring as soon as
+         * someone either destroys or restarts the trace. At that point,
+         * any remaining packets from the old ring will be recognisable
+         * as invalid.
+         */
 }
 
 #define REPEAT_16(x) x x x x x x x x x x x x x x x x

--- a/lib/format_pcap.c
+++ b/lib/format_pcap.c
@@ -499,7 +499,7 @@ static int pcap_write_packet(libtrace_out_t *libtrace,
 
 	/* Silently discard RT metadata packets and packets with an
 	 * unknown linktype. */
-	if (linktype == TRACE_TYPE_NONDATA || linktype == TRACE_TYPE_UNKNOWN || linktype == TRACE_TYPE_ERF_META) {
+	if (linktype == TRACE_TYPE_NONDATA || linktype == TRACE_TYPE_UNKNOWN || linktype == TRACE_TYPE_ERF_META || linktype == TRACE_TYPE_CONTENT_INVALID) {
 		return 0;
 	}
 
@@ -594,7 +594,7 @@ static int pcapint_write_packet(libtrace_out_t *libtrace,
 
 	/* Silently discard RT metadata packets and packets with an
 	 * unknown linktype. */
-	if (linktype == TRACE_TYPE_NONDATA || linktype == TRACE_TYPE_UNKNOWN || linktype == TRACE_TYPE_ERF_META) {
+	if (linktype == TRACE_TYPE_NONDATA || linktype == TRACE_TYPE_UNKNOWN || linktype == TRACE_TYPE_ERF_META || linktype == TRACE_TYPE_CONTENT_INVALID) {
 		return 0;
 	}
 

--- a/lib/format_pcapfile.c
+++ b/lib/format_pcapfile.c
@@ -431,7 +431,7 @@ static int pcapfile_write_packet(libtrace_out_t *out,
 	
 	/* Silently discard RT metadata packets and packets with an
 	 * unknown linktype. */
-	if (linktype == TRACE_TYPE_NONDATA || linktype == TRACE_TYPE_UNKNOWN || linktype == TRACE_TYPE_ERF_META) {
+	if (linktype == TRACE_TYPE_NONDATA || linktype == TRACE_TYPE_UNKNOWN || linktype == TRACE_TYPE_ERF_META || linktype == TRACE_TYPE_CONTENT_INVALID) {
 		return 0;
 	}
 

--- a/lib/libtrace.h.in
+++ b/lib/libtrace.h.in
@@ -346,7 +346,8 @@ typedef enum {
 } libtrace_dlt_t ;
 
 /** Enumeration of link layer types supported by libtrace */
-typedef enum { 
+typedef enum {
+       TRACE_TYPE_CONTENT_INVALID = -2, /**< Packet contents are not valid */
        TRACE_TYPE_UNKNOWN = -1,		/**< Unable to determine link type */
     /* TRACE_TYPE_LEGACY = 0 		Obsolete */
        TRACE_TYPE_HDLC_POS = 1, 	/**< HDLC over POS */
@@ -566,6 +567,7 @@ typedef struct libtrace_packet_t {
 
         pthread_mutex_t ref_lock;       /**< Lock for reference counter */
         int refcount;                 /**< Reference counter */
+        int which_trace_start;          /**< Used to match packet to a started instance of the parent trace */
 
 } libtrace_packet_t;
 

--- a/lib/libtrace_int.h
+++ b/lib/libtrace_int.h
@@ -336,6 +336,8 @@ struct libtrace_t {
 	libtrace_err_t err;
 	/** Boolean flag indicating whether the trace has been started */
 	bool started;
+        /** Number of times this trace has been started */
+        int startcount;
 	/** Synchronise writes/reads across this format object and attached threads etc */
 	pthread_mutex_t libtrace_lock;
 	/** Packet read lock, seperate from libtrace_lock as to not block while reading a burst */

--- a/lib/linktypes.c
+++ b/lib/linktypes.c
@@ -111,6 +111,7 @@ libtrace_dlt_t libtrace_to_pcap_dlt(libtrace_linktype_t type)
                 case TRACE_TYPE_ETSILI:
 			break;
 		case TRACE_TYPE_UNKNOWN:
+                case TRACE_TYPE_CONTENT_INVALID:
 			break;
 	}
 	return TRACE_DLT_ERROR;
@@ -213,6 +214,7 @@ uint8_t libtrace_to_erf_type(libtrace_linktype_t linktype)
 		case TRACE_TYPE_OPENBSD_LOOP:
                 case TRACE_TYPE_ETSILI:
 		case TRACE_TYPE_UNKNOWN:
+		case TRACE_TYPE_CONTENT_INVALID:
 			break;
 	}
 	return 255;
@@ -332,6 +334,7 @@ bool demote_packet(libtrace_packet_t *packet)
 	char *tmp;
 	struct timeval tv;
 	static libtrace_t *trace = NULL;
+
 	switch(trace_get_link_type(packet)) {
 		case TRACE_TYPE_ATM:
 			remaining=trace_get_capture_length(packet);
@@ -370,6 +373,7 @@ bool demote_packet(libtrace_packet_t *packet)
 				trace = trace_create_dead("pcapfile:-");
 			}
 
+                        trace->startcount = packet->trace->startcount;
 			packet->trace=trace;
 
 			/* Invalidate caches */
@@ -409,6 +413,7 @@ bool demote_packet(libtrace_packet_t *packet)
 			trace_clear_cache(packet);
 			break;
 		default:
+                        assert(0);
 			return false;
 	}
 

--- a/lib/protocols_l2.c
+++ b/lib/protocols_l2.c
@@ -485,6 +485,7 @@ DLLEXPORT void *trace_get_layer2(const libtrace_packet_t *packet,
                 case TRACE_TYPE_ETSILI:
 			break;
 		case TRACE_TYPE_UNKNOWN:
+		case TRACE_TYPE_CONTENT_INVALID:
 			return NULL;
 	}
 
@@ -522,6 +523,7 @@ DLLEXPORT void *trace_get_layer2(const libtrace_packet_t *packet,
                                 case TRACE_TYPE_ETSILI:
 					break;
 				case TRACE_TYPE_UNKNOWN:
+		                case TRACE_TYPE_CONTENT_INVALID:
 					return NULL;
 			}
 			
@@ -564,7 +566,8 @@ DLLEXPORT void *trace_get_payload_from_layer2(void *link,
 {
 	void *l;
 
-	if (linktype == TRACE_TYPE_UNKNOWN) {
+	if (linktype == TRACE_TYPE_UNKNOWN ||
+                        linktype == TRACE_TYPE_CONTENT_INVALID) {
 		fprintf(stderr, "Unable to determine linktype for packet\n");
 		return NULL;
 	}
@@ -588,6 +591,7 @@ DLLEXPORT void *trace_get_payload_from_layer2(void *link,
 		case TRACE_TYPE_METADATA:
 		case TRACE_TYPE_NONDATA:
 		case TRACE_TYPE_ERF_META:
+		case TRACE_TYPE_CONTENT_INVALID:
 		case TRACE_TYPE_UNKNOWN:
 			return NULL;
 
@@ -692,6 +696,7 @@ DLLEXPORT uint8_t *trace_get_source_mac(libtrace_packet_t *packet) {
 		case TRACE_TYPE_OPENBSD_LOOP:
 		case TRACE_TYPE_ERF_META:
 		case TRACE_TYPE_UNKNOWN:
+		case TRACE_TYPE_CONTENT_INVALID:
                         return NULL;
 
                 /* Metadata headers should already be skipped */
@@ -743,6 +748,7 @@ DLLEXPORT uint8_t *trace_get_destination_mac(libtrace_packet_t *packet)
 		case TRACE_TYPE_OPENBSD_LOOP:
 		case TRACE_TYPE_ERF_META:
 		case TRACE_TYPE_UNKNOWN:
+		case TRACE_TYPE_CONTENT_INVALID:
                         /* No MAC address */
                         return NULL;
                 /* Metadata headers should already be skipped */

--- a/lib/protocols_pktmeta.c
+++ b/lib/protocols_pktmeta.c
@@ -185,6 +185,7 @@ DLLEXPORT void *trace_get_packet_meta(const libtrace_packet_t *packet,
 		case TRACE_TYPE_NONDATA:
 		case TRACE_TYPE_OPENBSD_LOOP:
 		case TRACE_TYPE_UNKNOWN:
+		case TRACE_TYPE_CONTENT_INVALID:
 			return NULL;
 	}
 
@@ -248,6 +249,7 @@ DLLEXPORT void *trace_get_payload_from_meta(const void *meta,
 		case TRACE_TYPE_OPENBSD_LOOP:
 		case TRACE_TYPE_ERF_META:
 		case TRACE_TYPE_UNKNOWN:
+		case TRACE_TYPE_CONTENT_INVALID:
 			/* In this case, the pointer passed in does not point
 			 * to a metadata header and so we cannot get the
 			 * payload.

--- a/lib/trace.c
+++ b/lib/trace.c
@@ -1620,7 +1620,6 @@ DLLEXPORT int trace_apply_filter(libtrace_filter_t *filter,
 				if (free_packet_needed) {
 					trace_destroy_packet(packet_copy);
 				}
-                                printf("x\n");
 				return -1;
 			}
 			linktype = trace_get_link_type(packet_copy);
@@ -1644,7 +1643,6 @@ DLLEXPORT int trace_apply_filter(libtrace_filter_t *filter,
 		if (free_packet_needed) {
 			trace_destroy_packet(packet_copy);
 		}
-                printf("xx\n");
 		return -1;
 	}
 
@@ -1674,9 +1672,6 @@ DLLEXPORT int trace_apply_filter(libtrace_filter_t *filter,
 	if (free_packet_needed) {
 		trace_destroy_packet(packet_copy);
 	}
-        if (ret < 0) {
-                printf("xxx\n");
-        }
 	return ret;
 #else
 	fprintf(stderr,"This version of libtrace does not have bpf filter support\n");

--- a/lib/trace_parallel.c
+++ b/lib/trace_parallel.c
@@ -1344,6 +1344,7 @@ static int trace_pread_packet_wrapper(libtrace_t *libtrace,
 				              "Packet passed to trace_read_packet() is invalid\n");
 				return -1;
 			}
+                        packets[i]->which_trace_start = libtrace->startcount;
 		}
 		do {
 			ret=libtrace->format->pread_packets(libtrace, t,
@@ -1459,6 +1460,7 @@ static int trace_prestart(libtrace_t * libtrace, void *global_blob,
 
 	if (err == 0) {
 		libtrace->started = true;
+                libtrace->startcount ++;
 		libtrace_change_state(libtrace, STATE_RUNNING, false);
 	}
 	return err;
@@ -1862,6 +1864,7 @@ DLLEXPORT int trace_pstart(libtrace_t *libtrace, void* global_blob,
 
 	/* Threads don't start */
 	libtrace->started = true;
+        libtrace->startcount ++;
 	libtrace_change_state(libtrace, STATE_RUNNING, false);
 
 	ret = 0;


### PR DESCRIPTION
Richard: can you just double check that everything I'm doing here looks reasonably sane to you?

Previously, we used to munmap ring rx buffers whenever the input was paused, which meant we could still have references to packets that now point to a freed buffer. Now, we only munmap the ring rx buffer when the trace is either destroyed or re-started, so any remaining packets are valid for as long as possible.

Also added a "start iteration" tag to each packet which can be used internally to identify packets that might be associated with a now-invalid buffer. Each time a trace is started, this tag is incremented so we can tell if any given packet belongs to the most recent, i.e. valid, rx buffer. Invalid packets will return error values if any processing functions (get timestamp, get layer 3, etc.) are called on them.

In the long term, we may want to reconsider whether the pause operation actually gives us anything useful -- how often is pausing and restarting a trace or live interface actually useful?