### PR TITLE
Check the pcap output device/trace before closing it

### DIFF
--- a/lib/format_pcap.c
+++ b/lib/format_pcap.c
@@ -399,7 +399,9 @@ static int pcap_fin_output(libtrace_out_t *libtrace)
 		pcap_dump_flush(OUTPUT.trace.dump);
 		pcap_dump_close(OUTPUT.trace.dump);
 	}
-	pcap_close(OUTPUT.trace.pcap);
+	if (OUTPUT.trace.pcap) {
+		pcap_close(OUTPUT.trace.pcap);
+	}
 	free(libtrace->format_data);
 	return 0;
 }


### PR DESCRIPTION
Fixes a segfault when a pcap output is opened and then closed before any output is written.