### PR TITLE
trace_post_reporter(): fully initialize message

### DIFF
--- a/lib/trace_parallel.c
+++ b/lib/trace_parallel.c
@@ -2447,8 +2447,11 @@ DLLEXPORT int trace_message_reporter(libtrace_t * libtrace, libtrace_message_t *
 
 DLLEXPORT int trace_post_reporter(libtrace_t *libtrace)
 {
-	libtrace_message_t message = {0, {.uint64=0}, NULL};
-	message.code = MESSAGE_POST_REPORTER;
+	libtrace_message_t message;
+        memset(&message, 0, sizeof(libtrace_message_t));
+        message.code = MESSAGE_POST_REPORTER;
+        message.data.uint64 = 0;
+        message.sender = NULL;
 	return trace_message_reporter(libtrace, (void *) &message);
 }
 


### PR DESCRIPTION
Valgrind complains that a call to write has a buffer that isn't fully
initialized. This is due to a possibility of the uninitialized bytes in
that structure could be sensitive memory from its previous contents.

This patch makes sure that the full libtrace_message_t gets initialized
with 0s and then proceeds to set the contents before moving on to
calling the function that calls write().