### PR TITLE
Correct error message when trace_start() isn't called

### DIFF
--- a/lib/trace.c
+++ b/lib/trace.c
@@ -1007,7 +1007,7 @@ DLLEXPORT int trace_read_packet(libtrace_t *libtrace, libtrace_packet_t *packet)
 		return -1;
 
 	if (!libtrace->started) {
-		trace_set_err(libtrace,TRACE_ERR_BAD_STATE,"You must call libtrace_start() before trace_read_packet()");
+		trace_set_err(libtrace,TRACE_ERR_BAD_STATE,"You must call trace_start() before trace_read_packet()");
 		return -1;
 	}
 

--- a/lib/trace_parallel.c
+++ b/lib/trace_parallel.c
@@ -1389,7 +1389,7 @@ static int trace_pread_packet_wrapper(libtrace_t *libtrace,
 		return -1;
 	if (!libtrace->started) {
 		trace_set_err(libtrace, TRACE_ERR_BAD_STATE,
-		              "You must call libtrace_start() before trace_read_packet()\n");
+		              "You must call trace_start() before trace_read_packet()\n");
 		return -1;
 	}
 


### PR DESCRIPTION
This patch makes sure that when trace_perror() is called, it displays
the correct missing function call.