### PR TITLE
Only bind ndag socket to multicast group

### DIFF
--- a/lib/format_ndag.c
+++ b/lib/format_ndag.c
@@ -208,10 +208,10 @@ static int join_multicast_group(char *groupaddr, char *localiface,
         hints.ai_flags = AI_PASSIVE;
         hints.ai_protocol = 0;
 
-        if (getaddrinfo(NULL, portstr, &hints, &gotten) != 0) {
+        if (getaddrinfo(groupaddr, portstr, &hints, &gotten) != 0) {
                 fprintf(stderr,
-                        "Call to getaddrinfo failed for NULL:%s -- %s\n",
-                                portstr, strerror(errno));
+                        "Call to getaddrinfo failed for %s:%s -- %s\n",
+                                groupaddr, portstr, strerror(errno));
                 return -1;
         }
 


### PR DESCRIPTION
Previously we were binding only to the port, which meant that we would receive all UDP traffic to the bound port on the given interface. This is especially problematic when we have other ndag clients on the same machine which have joined other multicast groups as then all clients would receive traffic (to the bound port) for all groups.