### PR TITLE
Fix DPDK compile errors when using DPDK 18.11

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -30,6 +30,20 @@ build-amd64-debian-stretch:
   only:
     - tags
 
+build-amd64-debian-buster:
+  stage: build
+  image: debian:buster
+  script:
+    - ./gitlab-build.sh
+    - mkdir -p built-packages/buster/
+    - mv ../*.deb built-packages/buster/
+  artifacts:
+    paths:
+      - built-packages/*
+    expire_in: 1 day
+  only:
+    - tags
+
 build-amd64-ubuntu-xenial:
   stage: build
   image: ubuntu:xenial

--- a/configure.in
+++ b/configure.in
@@ -368,106 +368,6 @@ if test "$with_dag" != no -a "$libtrace_dag" = false; then
 
 fi
 
-# Try to determine the DAG driver version
-#if test x"$libtrace_dag" = xtrue; then
-#       dag_drv_v="Unknown"
-#	files=`locate /usr/*dag*/VERSION`
-#       file_count=0
-#
-#       for i in $files; do
-#                if $file_count > 0; then
-#                        dag_drv_v="Indeterminate"
-#                        break
-#                fi
-#                dag_drv_v=`cat $i`
-#                file_count=$file_count+1
-#        done
-#fi
-#DAG_VERSION_NUM=$dag_drv_v
-
-# Check for DPDK 
-AC_ARG_WITH(dpdk,
-	    AS_HELP_STRING(--with-dpdk,include DPDK live capture support (From either the RTE_SDK/_TARGET environment variable or the dpdk-dev package)),
-[
-        if test "$withval" = no
-        then
-            want_dpdk=no
-        else
-            want_dpdk=ifpresent
-        fi
-],[
-        # Default to building without DPDK format
-        want_dpdk=no
-])
-
-libtrace_dpdk=false
-if test "$want_dpdk" != no; then
-
-        PKG_CHECK_MODULES([DPDK], [libdpdk >= 18], [pkgconf_dpdk_found="yes"],
-                [pkgconf_dpdk_found="no"])
-        if test "x$pkgconf_dpdk_found" = "xyes"; then
-                LIBTRACE_LIBS="$LIBTRACE_LIBS $DPDK_LIBS"
-                ADD_INCLS="$ADD_INCLS $DPDK_CFLAGS"
-                AC_MSG_NOTICE([Building against system DPDK])
-
-                AC_DEFINE(HAVE_DPDK,1,[conditional for building with DPDK live capture support])
-                AC_DEFINE(HAVE_DPDK18,1,[using dpdk version 18 or later])
-                libtrace_dpdk=true
-                dpdk_found=pkgconfig
-        fi
-
-
-	# So instead simply check for existence
-	if test "$dpdk_found" = 0 -a "$RTE_SDK" != ""; then
-		AC_CHECK_FILE("$RTE_SDK/$RTE_TARGET/lib/libdpdk.so", dpdk_found="dpdk", dpdk_found=0)
-	fi
-	if test "$dpdk_found" = 0 -a "$RTE_SDK" != ""; then
-		AC_CHECK_FILE("$RTE_SDK/$RTE_TARGET/lib/libintel_dpdk.a", dpdk_found=":libintel_dpdk.a", dpdk_found=0)
-	fi
-	# DPDK 2.1.0+ renames this to libdpdk from libintel_dpdk
-	if test "$dpdk_found" = 0 -a "$RTE_SDK" != ""; then
-		AC_CHECK_FILE("$RTE_SDK/$RTE_TARGET/lib/libdpdk.a", dpdk_found=":libdpdk.a", dpdk_found=0)
-	fi
-	if test "$dpdk_found" = 0 -a "$RTE_SDK" != ""; then
-		AC_CHECK_LIB(dpdk, rte_eth_dev_configure, dpdk_found="dpdk", dpdk_found=0)
-	fi
-	if test "$dpdk_found" != 0 -a "$RTE_SDK" != ""; then
-		# Save these now so that they can be re-exported later
-		AC_SUBST([RTE_TARGET])
-		AC_SUBST([RTE_SDK])
-		# Force dpdk library to be statically linked to allow compiler optimisations
-		LIBTRACE_LIBS="$LIBTRACE_LIBS -Wl,--whole-archive -Wl,-l$dpdk_found -Wl,--no-whole-archive -Wl,-lm"
-		AC_DEFINE(HAVE_DPDK,1,[conditional for building with DPDK live capture support])
-		libtrace_dpdk=true
-	fi
-
-	if test "$dpdk_found" = 0 -a "$RTE_SDK" = ""; then
-		AC_MSG_NOTICE([No RTE_SDK given, checking for system dpdk-dev package])
-		# Search the system, maybe it is installed? Ethdev is one of the main libraries
-		# On Ubuntu and Debian we can simply check for dpdk.so
-		AC_CHECK_LIB(dpdk, rte_eth_dev_configure, dpdk_found="system", dpdk_found=0)
-		# We also need to check that rte.vars.mk is installed from dpdk-dev (as well as libdpdk-dev)
-		if test "$dpdk_found" != 0 -a -e /usr/share/dpdk/mk/rte.vars.mk ; then
-			RTE_TARGET="$(uname -m)-default-linuxapp-gcc"
-			RTE_SDK="/usr/share/dpdk/"
-			RTE_INCLUDE="/usr/include/dpdk"
-			AC_SUBST([RTE_TARGET])
-			AC_SUBST([RTE_SDK])
-			AC_SUBST([RTE_INCLUDE])
-			LIBTRACE_LIBS="$LIBTRACE_LIBS -ldpdk"
-			AC_MSG_NOTICE([Building against system DPDK])
-
-			AC_DEFINE(HAVE_DPDK,1,[conditional for building with DPDK live capture support])
-			libtrace_dpdk=true
-			dpdk_found=system
-		fi
-	fi
-
-        if test "$dpdk_found" = 0 -a "$with_dpdk" = "yes"; then
-                AC_MSG_ERROR("Unable to find DPDK on system. Build halted -- consider re-running configure with '--with-dpdk=no'.")
-        fi
-fi
-
 # Check for PACKET_FANOUT (borrowed from Suricata)
 AC_CHECK_DECL([PACKET_FANOUT],
         AC_DEFINE([HAVE_PACKET_FANOUT],[1],
@@ -485,6 +385,25 @@ AC_CHECK_LIB(wandder, init_wandder_decoder, have_wandder=1, have_wandder=0)
 AC_CHECK_LIB(pthread, pthread_create, have_pthread=1, have_pthread=0)
 
 AC_CHECK_LIB(pthread, pthread_setname_np, have_pthread_setname_np=1, have_pthread_setname_np=0)
+
+
+
+# Try to determine the DAG driver version
+#if test x"$libtrace_dag" = xtrue; then
+#       dag_drv_v="Unknown"
+#	files=`locate /usr/*dag*/VERSION`
+#       file_count=0
+#
+#       for i in $files; do
+#                if $file_count > 0; then
+#                        dag_drv_v="Indeterminate"
+#                        break
+#                fi
+#                dag_drv_v=`cat $i`
+#                file_count=$file_count+1
+#        done
+#fi
+#DAG_VERSION_NUM=$dag_drv_v
 
 # Check for ncurses
 
@@ -576,6 +495,93 @@ if test "$have_clock_gettime" = 1; then
 	with_clock_gettime=yes
 else
 	with_clock_gettime=no
+fi
+
+# Check for DPDK 
+AC_ARG_WITH(dpdk,
+	    AS_HELP_STRING(--with-dpdk,include DPDK live capture support (From either the RTE_SDK/_TARGET environment variable or the dpdk-dev package)),
+[
+        if test "$withval" = no
+        then
+            want_dpdk=no
+        else
+            want_dpdk=ifpresent
+        fi
+],[
+        # Default to building without DPDK format
+        want_dpdk=no
+])
+
+libtrace_dpdk=false
+if test "$want_dpdk" != no; then
+
+        PKG_CHECK_MODULES([DPDK], [libdpdk >= 18], [pkgconf_dpdk_found="yes"],
+                [pkgconf_dpdk_found="no"])
+        if test "x$pkgconf_dpdk_found" = "xyes"; then
+                LIBTRACE_LIBS="$LIBTRACE_LIBS $DPDK_LIBS"
+                ADD_INCLS="$ADD_INCLS $DPDK_CFLAGS"
+                AC_MSG_NOTICE([Building against system DPDK])
+                dpdk_found=pkgconfig
+        else
+                dpdk_found=0
+        fi
+
+
+	# So instead simply check for existence
+	if test "$dpdk_found" = 0 -a "$RTE_SDK" != ""; then
+		AC_CHECK_FILE("$RTE_SDK/$RTE_TARGET/lib/libdpdk.so", dpdk_found="dpdk", dpdk_found=0)
+	fi
+	if test "$dpdk_found" = 0 -a "$RTE_SDK" != ""; then
+		AC_CHECK_FILE("$RTE_SDK/$RTE_TARGET/lib/libintel_dpdk.a", dpdk_found=":libintel_dpdk.a", dpdk_found=0)
+	fi
+	# DPDK 2.1.0+ renames this to libdpdk from libintel_dpdk
+	if test "$dpdk_found" = 0 -a "$RTE_SDK" != ""; then
+		AC_CHECK_FILE("$RTE_SDK/$RTE_TARGET/lib/libdpdk.a", dpdk_found=":libdpdk.a", dpdk_found=0)
+	fi
+	if test "$dpdk_found" = 0 -a "$RTE_SDK" != ""; then
+		AC_CHECK_LIB(dpdk, rte_eth_dev_configure, dpdk_found="dpdk", dpdk_found=0)
+	fi
+	if test "$dpdk_found" != 0 -a "$RTE_SDK" != ""; then
+		# Save these now so that they can be re-exported later
+		AC_SUBST([RTE_TARGET])
+		AC_SUBST([RTE_SDK])
+		# Force dpdk library to be statically linked to allow compiler optimisations
+		LIBTRACE_LIBS="$LIBTRACE_LIBS -Wl,--whole-archive -Wl,-l$dpdk_found -Wl,--no-whole-archive -Wl,-lm"
+
+	fi
+
+	if test "$dpdk_found" = 0 -a "$RTE_SDK" = ""; then
+		AC_MSG_NOTICE([No RTE_SDK given, checking for system dpdk-dev package])
+		# Search the system, maybe it is installed? Ethdev is one of the main libraries
+		# On Ubuntu and Debian we can simply check for dpdk.so
+		AC_CHECK_LIB(dpdk, rte_eth_dev_configure, dpdk_found="system", dpdk_found=0)
+		# We also need to check that rte.vars.mk is installed from dpdk-dev (as well as libdpdk-dev)
+		if test "$dpdk_found" != 0 -a -e /usr/share/dpdk/mk/rte.vars.mk ; then
+			RTE_TARGET="$(uname -m)-default-linuxapp-gcc"
+			RTE_SDK="/usr/share/dpdk/"
+			RTE_INCLUDE="/usr/include/dpdk"
+			AC_SUBST([RTE_TARGET])
+			AC_SUBST([RTE_SDK])
+			AC_SUBST([RTE_INCLUDE])
+			LIBTRACE_LIBS="$LIBTRACE_LIBS -ldpdk"
+			AC_MSG_NOTICE([Building against system DPDK])
+
+			dpdk_found=system
+		fi
+	fi
+
+        if test "$dpdk_found" != 0; then
+		AC_DEFINE(HAVE_DPDK,1,[conditional for building with DPDK live capture support])
+                LIBS="$LIBTRACE_LIBS"
+                AC_CHECK_FUNC(rte_devargs_add, [AC_DEFINE(HAVE_DPDK18,1,using dpdk version 18 or later)])
+                LIBS=""
+                libtrace_dpdk=true
+        fi
+
+
+        if test "$dpdk_found" = 0 -a "$with_dpdk" = "yes"; then
+                AC_MSG_ERROR("Unable to find DPDK on system. Build halted -- consider re-running configure with '--with-dpdk=no'.")
+        fi
 fi
 
 

--- a/configure.in
+++ b/configure.in
@@ -402,8 +402,23 @@ AC_ARG_WITH(dpdk,
 
 libtrace_dpdk=false
 if test "$want_dpdk" != no; then
+
+        PKG_CHECK_MODULES([DPDK], [libdpdk >= 18], [pkgconf_dpdk_found="yes"],
+                [pkgconf_dpdk_found="no"])
+        if test "x$pkgconf_dpdk_found" = "xyes"; then
+                LIBTRACE_LIBS="$LIBTRACE_LIBS $DPDK_LIBS"
+                ADD_INCLS="$ADD_INCLS $DPDK_CFLAGS"
+                AC_MSG_NOTICE([Building against system DPDK])
+
+                AC_DEFINE(HAVE_DPDK,1,[conditional for building with DPDK live capture support])
+                AC_DEFINE(HAVE_DPDK18,1,[using dpdk version 18 or later])
+                libtrace_dpdk=true
+                dpdk_found=pkgconfig
+        fi
+
+
 	# So instead simply check for existence
-	if test "$RTE_SDK" != ""; then
+	if test "$dpdk_found" = 0 -a "$RTE_SDK" != ""; then
 		AC_CHECK_FILE("$RTE_SDK/$RTE_TARGET/lib/libdpdk.so", dpdk_found="dpdk", dpdk_found=0)
 	fi
 	if test "$dpdk_found" = 0 -a "$RTE_SDK" != ""; then
@@ -425,7 +440,8 @@ if test "$want_dpdk" != no; then
 		AC_DEFINE(HAVE_DPDK,1,[conditional for building with DPDK live capture support])
 		libtrace_dpdk=true
 	fi
-	if test "$RTE_SDK" = ""; then
+
+	if test "$dpdk_found" = 0 -a "$RTE_SDK" = ""; then
 		AC_MSG_NOTICE([No RTE_SDK given, checking for system dpdk-dev package])
 		# Search the system, maybe it is installed? Ethdev is one of the main libraries
 		# On Ubuntu and Debian we can simply check for dpdk.so
@@ -446,6 +462,10 @@ if test "$want_dpdk" != no; then
 			dpdk_found=system
 		fi
 	fi
+
+        if test "$dpdk_found" = 0 -a "$with_dpdk" = "yes"; then
+                AC_MSG_ERROR("Unable to find DPDK on system. Build halted -- consider re-running configure with '--with-dpdk=no'.")
+        fi
 fi
 
 # Check for PACKET_FANOUT (borrowed from Suricata)
@@ -653,6 +673,8 @@ AM_CONDITIONAL([HAVE_LIBGDC], [test "$ac_cv_header_gdc_h" = yes])
 AM_CONDITIONAL([HAVE_LLVM], [test "x$JIT" != "xno" ])
 AM_CONDITIONAL([HAVE_NCURSES], [test "x$with_ncurses" != "xno"])
 AM_CONDITIONAL([HAVE_YAML], [test "x$have_yaml" != "xno"])
+
+AM_CONDITIONAL([HAVE_DPDK_PKGCONFIG], [test "x$dpdk_found" = "xpkgconfig"])
 
 # Check for miscellaneous programs
 AC_CHECK_PROG([libtrace_doxygen], [doxygen], [true], [false])

--- a/gitlab-build.sh
+++ b/gitlab-build.sh
@@ -10,7 +10,8 @@ SOURCENAME=`echo ${CI_COMMIT_REF_NAME} | cut -d '-' -f 1`
 
 apt-get update
 apt-get install -y equivs devscripts dpkg-dev quilt curl apt-transport-https \
-    apt-utils ssl-cert ca-certificates gnupg lsb-release debhelper git
+    apt-utils ssl-cert ca-certificates gnupg lsb-release debhelper git \
+    pkg-config
 
 echo "deb https://dl.bintray.com/wand/general $(lsb_release -sc) main" | \
     tee -a /etc/apt/sources.list.d/wand.list

--- a/gitlab-build.sh
+++ b/gitlab-build.sh
@@ -6,6 +6,8 @@ export DEBEMAIL='packaging@wand.net.nz'
 export DEBFULLNAME='WAND Packaging'
 export DEBIAN_FRONTEND=noninteractive
 
+SOURCENAME=`echo ${CI_COMMIT_REF_NAME} | cut -d '-' -f 1`
+
 apt-get update
 apt-get install -y equivs devscripts dpkg-dev quilt curl apt-transport-https \
     apt-utils ssl-cert ca-certificates gnupg lsb-release debhelper git
@@ -20,6 +22,6 @@ curl --silent "https://bintray.com/user/downloadSubjectPublicKey?username=wand"\
 apt-get update
 apt-get upgrade -y
 
-dpkg-parsechangelog -S version | grep -q ${CI_COMMIT_REF_NAME} || debchange --newversion ${CI_COMMIT_REF_NAME} -b "New upstream release"
+dpkg-parsechangelog -S version | grep -q ${SOURCENAME} || debchange --newversion ${SOURCENAME} -b "New upstream release"
 mk-build-deps -i -r -t 'apt-get -f -y --force-yes'
 dpkg-buildpackage -b -us -uc -rfakeroot -j4

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -44,7 +44,11 @@ export SAVED_CFLAGS:=$(CFLAGS)
 export SAVED_CXXFLAGS:=$(CXXFLAGS)
 export SAVED_CPPFLAGS:=$(CPPFLAGS)
 export SAVED_LDFLAGS:=$(LDFLAGS)
+
+if HAVE_DPDK_PKGCONFIG
+else
 include $(RTE_SDK)/mk/rte.vars.mk
+endif
 # We need to add -Wl before the linker otherwise this breaks our build
 # And include any libraries that DPDK might depend upon
 export DPDK_LIBTRACE_MK=dpdk_libtrace.mk

--- a/lib/format_dag25.c
+++ b/lib/format_dag25.c
@@ -512,7 +512,7 @@ static int dag_init_input(libtrace_t *libtrace) {
 	 * list */
 	pthread_mutex_lock(&open_dag_mutex);
 
-
+        FORMAT_DATA->stream_attached = 0;
 	/* DAG cards support multiple streams. In a single threaded capture,
 	 * these are specified using a comma in the libtrace URI,
 	 * e.g. dag:/dev/dag0,2 refers to stream 2 on the dag0 device.
@@ -544,11 +544,11 @@ static int dag_init_input(libtrace_t *libtrace) {
 
 	/* Make sure we have successfully opened a DAG device */
 	if (dag_device == NULL) {
+		trace_set_err(libtrace, TRACE_ERR_INIT_FAILED, "Unable to open DAG device %s", dag_dev_name);
 		if (dag_dev_name)
 			free(dag_dev_name);
 		dag_dev_name = NULL;
 		pthread_mutex_unlock(&open_dag_mutex);
-		trace_set_err(libtrace, TRACE_ERR_INIT_FAILED, "Unable to open DAG device %s", dag_dev_name);
 		return -1;
 	}
 

--- a/lib/format_pcapng.c
+++ b/lib/format_pcapng.c
@@ -2100,6 +2100,7 @@ static libtrace_meta_datatype_t pcapng_get_datatype(uint32_t section, uint32_t o
 		default:
 			return TRACE_META_UNKNOWN;
 	}
+        return TRACE_META_UNKNOWN;
 }
 
 static void *pcapng_jump_to_options(libtrace_packet_t *packet) {


### PR DESCRIPTION
Buster and disco only include packages for DPDK 18.11, so we need to move towards a version of libtrace that will actually work with more recent DPDK releases.

Of course, this means we have a bunch of annoying API changes to account for since the DPDK folks can't seem to stop changing user-facing structures or function names.

Couple of other fixes included in here too:
 * Fixed missing return value warning in `pcapng_get_datatype()`
 * Fix segfault when a DAG device fails to open
 * Have `configure` halt with an error if the user explicitly asks for DPDK and it can't be found, rather than just silently building a DPDK-less version instead.