### PR TITLE
Bug fixes for 4.0.10, prep for 4.0.11

### DIFF
--- a/README
+++ b/README
@@ -1,7 +1,7 @@
-libtrace 4.0.10
+libtrace 4.0.11
 
 ---------------------------------------------------------------------------
-Copyright (c) 2007-2019 The University of Waikato, Hamilton, New Zealand.
+Copyright (c) 2007-2020 The University of Waikato, Hamilton, New Zealand.
 All rights reserved.
 
 This code has been developed by the University of Waikato WAND

--- a/configure.in
+++ b/configure.in
@@ -3,11 +3,11 @@
 # Now you only need to update the version number in two places - below,
 # and in the README
 
-AC_INIT([libtrace],[4.0.10],[contact@wand.net.nz],[libtrace])
+AC_INIT([libtrace],[4.0.11],[contact@wand.net.nz],[libtrace])
 
 LIBTRACE_MAJOR=4
 LIBTRACE_MID=0
-LIBTRACE_MINOR=10
+LIBTRACE_MINOR=11
 
 # OpenSolaris hides libraries like libncurses in /usr/gnu/lib, which is not
 # searched by default - add it to LDFLAGS so we at least have a chance of 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,23 @@
+libtrace4 (4.0.11-1) unstable; urgency=medium
+
+  * New upstream release.
+  * Fix bug where trace_apply_filter() would not work correctly with a
+    parallel trace input.
+  * Fix bug where non-parallel ETSI programs would fail to halt nicely.
+  * Fix libpacketdump being unable to decode Ethernet within MPLS properly.
+  * Fix libtrace (trace_get_layer3()) being unable to decode Ethernet
+    within MPLS properly.
+  * tracereplay now strips VLAN and MPLS headers before trying to replay a
+    packet from a trace file.
+  * Fix bug where the simple circular buffer would leak shared memory files.
+  * Fix segfault when using trace_apply_filter() on a packet which came from
+    an input trace that is now "closed".
+  * Fix bug where libtrace could try to flush a NULL pcap file handle.
+  * debian-specific: fix missing dependency on libpacketdump4 for
+    libtrace4-tools.
+
+ -- Shane Alcock <shane.alcock@waikato.ac.nz>  Thu, 13 Feb 2020 15:09:44 +1300
+
 libtrace4 (4.0.10-1) unstable; urgency=medium
 
   * New upstream release.

--- a/debian/control
+++ b/debian/control
@@ -94,7 +94,7 @@ Description: network packet parsing and human-readable display library
 Package: libtrace4-tools
 Section: net
 Architecture: any
-Depends: libtrace4 (= ${binary:Version}), ${misc:Depends}
+Depends: libtrace4 (= ${binary:Version}), libpacketdump4 (= ${binary:Version}), ${misc:Depends}
 Conflicts: libtrace-tools
 Replaces: libtrace-tools
 Description: helper utilities for use with the libtrace process library

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -94,7 +94,7 @@ endif
 
 AM_CPPFLAGS= @ADD_INCLS@
 libtrace_la_LIBADD = @LIBTRACE_LIBS@ @LTLIBOBJS@ $(DPDKLIBS)
-libtrace_la_LDFLAGS=-version-info 5:3:1 @ADD_LDFLAGS@
+libtrace_la_LDFLAGS=-version-info 5:4:1 @ADD_LDFLAGS@
 dagapi.c:
 	cp @DAG_TOOLS_DIR@/dagapi.c .
 

--- a/lib/data-struct/simple_circular_buffer.c
+++ b/lib/data-struct/simple_circular_buffer.c
@@ -13,6 +13,7 @@
 #include <sys/socket.h>
 #include <errno.h>
 #include <sys/types.h>
+#include <string.h>
 
 #include "simple_circular_buffer.h"
 

--- a/lib/data-struct/simple_circular_buffer.c
+++ b/lib/data-struct/simple_circular_buffer.c
@@ -25,6 +25,13 @@ DLLEXPORT int libtrace_scb_init(libtrace_scb_t *buf, uint32_t size,
                 size = ((size / getpagesize()) + 1) * getpagesize();
         }
 
+        /* This SCB has not been cleaned up properly, do so now to
+         * try and avoid leaking fds and/or mmapped memory.
+         */
+        if (buf->fd != -1 || buf->address != NULL) {
+                libtrace_scb_destroy(buf);
+        }
+
         snprintf(anonname, 32, "lt_scb_%u_%u", getpid(), id);
 #ifdef HAVE_MEMFD_CREATE
         buf->fd = syscall(__NR_memfd_create, anonname, 0);
@@ -47,6 +54,7 @@ DLLEXPORT int libtrace_scb_init(libtrace_scb_t *buf, uint32_t size,
         buf->read_offset = 0;
         buf->write_offset = 0;
         buf->count_bytes = size;
+        buf->shm_file = strdup(anonname);
 
         if (buf->address) {
                 return 0;
@@ -59,10 +67,17 @@ DLLEXPORT void libtrace_scb_destroy(libtrace_scb_t *buf) {
 
         if (buf->address) {
                 munmap(buf->address, buf->count_bytes * 2);
+                buf->address = NULL;
         }
         if (buf->fd != -1) {
                 close(buf->fd);
+                buf->fd = -1;
         }
+        if (buf->shm_file) {
+                shm_unlink(buf->shm_file);
+                free(buf->shm_file);
+        }
+
 }
 
 DLLEXPORT int libtrace_scb_recv_sock(libtrace_scb_t *buf, int sock,

--- a/lib/data-struct/simple_circular_buffer.h
+++ b/lib/data-struct/simple_circular_buffer.h
@@ -4,6 +4,7 @@
 #include "libtrace.h"
 
 typedef struct libtracescb {
+        char *shm_file;
         uint8_t *address;
         uint32_t count_bytes;
         uint32_t write_offset;

--- a/lib/format_etsilive.c
+++ b/lib/format_etsilive.c
@@ -325,8 +325,12 @@ static void halt_etsi_thread(etsithread_t *receiver) {
 static int etsilive_pause_input(libtrace_t *libtrace) {
 
         int i;
-        for (i = 0; i < libtrace->perpkt_thread_count; i++) {
-                halt_etsi_thread(&(FORMAT_DATA->receivers[i]));
+        if (libtrace->perpkt_thread_count == 0) {
+                halt_etsi_thread(&(FORMAT_DATA->receivers[0]));
+        } else {
+                for (i = 0; i < libtrace->perpkt_thread_count; i++) {
+                        halt_etsi_thread(&(FORMAT_DATA->receivers[i]));
+                }
         }
         return 0;
 
@@ -411,6 +415,7 @@ static void receive_from_single_socket(etsisocket_t *esock, etsithread_t *et) {
                 close(esock->sock);
                 esock->sock = -1;
                 et->activesources -= 1;
+                libtrace_scb_destroy(&(esock->recvbuffer));
         }
 
         if (ret == 0) {
@@ -418,6 +423,7 @@ static void receive_from_single_socket(etsisocket_t *esock, etsithread_t *et) {
                 close(esock->sock);
                 esock->sock = -1;
                 et->activesources -= 1;
+                libtrace_scb_destroy(&(esock->recvbuffer));
         }
 
 }

--- a/lib/protocols_l3.c
+++ b/lib/protocols_l3.c
@@ -266,7 +266,7 @@ DLLEXPORT void *trace_get_layer3(const libtrace_packet_t *packet,
 			iphdr=trace_get_payload_from_mpls(
 					  iphdr,ethertype,remaining);
 
-			if (iphdr && ethertype == 0x0) {
+			if (iphdr && *ethertype == 0x0) {
 				iphdr=trace_get_payload_from_ethernet(
 						iphdr,ethertype,remaining);
 			}

--- a/lib/trace.c
+++ b/lib/trace.c
@@ -1767,6 +1767,11 @@ DLLEXPORT int trace_apply_filter(libtrace_filter_t *filter,
 		/* Copy the packet, as we don't want to trash the one we
 		 * were passed in */
 		packet_copy=trace_copy_packet(packet);
+                if (packet_copy == NULL) {
+                        trace_set_err(packet->trace, TRACE_ERR_NO_CONVERSION,
+                                        "failed to demote packet within trace_apply_filter()");
+                        return -1;
+                }
 		free_packet_needed=true;
 
 		while (libtrace_to_pcap_dlt(linktype) == TRACE_DLT_ERROR) {

--- a/lib/trace_parallel.c
+++ b/lib/trace_parallel.c
@@ -1370,6 +1370,7 @@ static inline size_t filter_packets(libtrace_t *trace,
 	for (i = 0; i < nb_packets; ++i) {
 		// The filter needs the trace attached to receive the link type
 		packets[i]->trace = trace;
+                packets[i]->which_trace_start = trace->startcount;
 		if (trace_apply_filter(trace->filter, packets[i])) {
 			libtrace_packet_t *tmp;
 			tmp = packets[offset];

--- a/libpacketdump/Makefile.am
+++ b/libpacketdump/Makefile.am
@@ -194,7 +194,7 @@ AM_CPPFLAGS= @ADD_INCLS@ -I../lib
 # a shared library.
 libpacketdump_la_LIBADD = @LIBPKTDUMP_LIBS@ 
 libpacketdump_la_LDFLAGS=\
-        -version-info 5:0:0 \
+        -version-info 5:1:0 \
         @ADD_LDFLAGS@
 
 AM_CXXFLAGS=-g -Wall -DDIRNAME=\"$(plugindir)\" $(AM_CPPFLAGS)

--- a/libpacketdump/eth_34887.c
+++ b/libpacketdump/eth_34887.c
@@ -67,7 +67,7 @@ DLLEXPORT void decode(int link_type UNUSED,const char *packet,unsigned len)
 	else if ((*(packet+4)&0xF0) == 0x60)
 		decode_next(packet+offset/8,len-4,"eth",0x86DD);
 	else
-		decode_next(packet+offset/8,len-4,"link",1);
+		decode_next(packet+offset/8,len-4,"link",2);
 
 	return;
 }

--- a/rpm/libtrace4.spec
+++ b/rpm/libtrace4.spec
@@ -1,5 +1,5 @@
 Name:           libtrace4
-Version:        4.0.10
+Version:        4.0.11
 Release:        1%{?dist}
 Summary:        C Library for capturing and analysing network packets
 
@@ -125,6 +125,9 @@ find $RPM_BUILD_ROOT -name '*.la' -exec rm -f {} ';'
 
 
 %changelog
+* Thu Feb 13 2020 Shane Alcock <salcock@waikato.ac.nz> - 4.0.11-1
+- Updated for 4.0.11 release
+
 * Wed Nov 6 2019 Shane Alcock <salcock@waikato.ac.nz> - 4.0.10-1
 - Go back to relying on standard DPDK packages
 

--- a/tools/tracereplay/tracereplay.c
+++ b/tools/tracereplay/tracereplay.c
@@ -119,14 +119,6 @@ static libtrace_packet_t * per_packet(libtrace_packet_t *packet) {
 		wire_length -= FCS_SIZE;
 	}
 
-        /* Quick hack to deal with pcap packets that are way larger than any
-         * sensible MTU (and therefore will never send without throwing an
-         * error).
-         */
-        if (wire_length > 8950) {
-                wire_length = 8950;
-        }
-
 	trace_construct_packet(new_packet,linktype,pkt_buffer,wire_length);
         new_packet = trace_strip_packet(new_packet);
 

--- a/tools/tracereplay/tracereplay.c
+++ b/tools/tracereplay/tracereplay.c
@@ -119,6 +119,14 @@ static libtrace_packet_t * per_packet(libtrace_packet_t *packet) {
 		wire_length -= FCS_SIZE;
 	}
 
+        /* Quick hack to deal with pcap packets that are way larger than any
+         * sensible MTU (and therefore will never send without throwing an
+         * error).
+         */
+        if (wire_length > 8950) {
+                wire_length = 8950;
+        }
+
 	trace_construct_packet(new_packet,linktype,pkt_buffer,wire_length);
 
 	if(broadcast) {

--- a/tools/tracereplay/tracereplay.c
+++ b/tools/tracereplay/tracereplay.c
@@ -128,6 +128,7 @@ static libtrace_packet_t * per_packet(libtrace_packet_t *packet) {
         }
 
 	trace_construct_packet(new_packet,linktype,pkt_buffer,wire_length);
+        new_packet = trace_strip_packet(new_packet);
 
 	if(broadcast) {
 		l2_header = trace_get_layer2(new_packet,&linktype,&remaining);


### PR DESCRIPTION
This PR contains all of the fixes for bugs found since the 4.0.10 release (see ChangeLog in the wiki for more details).

Prepares libtrace for a 4.0.11 release.