### PR TITLE
Add support for processing nDAG Corsaro Tagged packets

### DIFF
--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -1,7 +1,7 @@
 lib_LTLIBRARIES = libtrace.la
 include_HEADERS = libtrace.h libtrace_parallel.h
 pkginclude_HEADERS = dagformat.h lt_inttypes.h daglegacy.h \
-        rt_protocol.h erftypes.h pthread_spinlock.h \
+        rt_protocol.h erftypes.h pthread_spinlock.h format_ndag.h \
         data-struct/ring_buffer.h data-struct/object_cache.h \
         data-struct/vector.h \
         data-struct/deque.h data-struct/linked_list.h \

--- a/lib/format_ndag.h
+++ b/lib/format_ndag.h
@@ -35,14 +35,117 @@
 #define NDAG_MAGIC_NUMBER (0x4E444147)
 #define NDAG_EXPORT_VERSION 1
 
+#define MAX_NETACQ_POLYGONS 8
 
 enum {
         NDAG_PKT_BEACON = 0x01,
         NDAG_PKT_ENCAPERF = 0x02,
         NDAG_PKT_RESTARTED = 0x03,
         NDAG_PKT_ENCAPRT = 0x04,
-        NDAG_PKT_KEEPALIVE = 0x05
+        NDAG_PKT_KEEPALIVE = 0x05,
+        NDAG_PKT_CORSAROTAG = 0x06
 };
+
+/** Must match the ipmeta_provider_id_t enum in libipmeta */
+enum {
+        NDAG_IPMETA_PROVIDER_MAXMIND = 1,
+        NDAG_IPMETA_PROVIDER_NETACQ_EDGE = 2,
+        NDAG_IPMETA_PROVIDER_PFX2AS = 3,
+};
+
+/** A set of tags that have been derived for an individual packet. */
+typedef struct corsaro_packet_tags {
+
+    /** A bitmap that is used to identify which libipmeta tags are
+     *  valid, i.e. which providers were enabled.
+     */
+    uint32_t providers_used;
+
+    /** The ID of the geo-location region for the source IP, as
+     *  determined using the netacq-edge data */
+    uint16_t netacq_region;
+
+    /** The ID of the geo-location 'polygon' for the source IP, as
+     *  determined using the netacq-edge data. Note that there can
+     *  be multiple polygons for a single packet, as there are
+     *  multiple sources of polygon data. */
+    uint32_t netacq_polygon[MAX_NETACQ_POLYGONS];
+
+    /** The ASN that owns the source IP, according to the prefix2asn
+     *  data. */
+    uint32_t prefixasn;
+
+    /** The 2-letter code describing the geo-location country
+     *  for the source IP, as determined using the maxmind data.
+     *  Encoded as a uint16_t, one byte for each character. */
+    uint16_t maxmind_country;
+
+    /** The 2-letter code describing the geo-location country
+     *  for the source IP, as determined using the netacq-edge data.
+     *  Encoded as a uint16_t, one byte for each character. */
+    uint16_t netacq_country;
+
+    /** The source port used by the packet */
+    uint16_t src_port;
+
+    /** The destiantion port used by the packet */
+    uint16_t dest_port;
+
+    /** The 2-letter code describing the geo-location continent
+     *  for the source IP, as determined using the maxmind data.
+     *  Encoded as a uint16_t, one byte for each character. */
+    uint16_t maxmind_continent;
+
+    /** The 2-letter code describing the geo-location continent
+     *  for the source IP, as determined using the netacq-edge data.
+     *  Encoded as a uint16_t, one byte for each character. */
+    uint16_t netacq_continent;
+
+    /** Bitmask showing which filters this packet matches, i.e.
+     * is it spoofed, is it erratic, is it non-routable */
+    uint64_t filterbits;
+
+    /** The hash of the flowtuple ID for this packet -- note this is more
+     *  than just a standard 5-tuple and includes fields such as TTL,
+     *  IP length, TCP flags etc.
+     */
+    uint32_t ft_hash;
+
+    /** The post-IP protocol used by the packet */
+    uint8_t protocol;
+} PACKED corsaro_packet_tags_t;
+
+
+/** Meta-data that is sent in advance of any published packets, including
+ *  the tags that were applied to the packet.
+ */
+typedef struct corsaro_tagged_packet_header {
+    uint8_t hashbin;
+
+    /** Bitmask showing which filters were matched by the packet.
+     *  MUST be the second field in this structure so that zeromq
+     *  subscription filtering can be applied properly.
+     */
+    uint16_t filterbits;
+
+    /** The seconds portion of the packet timestamp */
+    uint32_t ts_sec;
+
+    /** The microseconds portion of the packet timestamp */
+    uint32_t ts_usec;
+
+    /** The length of the packet, starting from the Ethernet header */
+    uint16_t pktlen;
+
+    uint16_t wirelen;
+
+    uint32_t tagger_id;
+
+    uint64_t seqno;
+
+    /** The tags that were applied to this packet by the tagging module */
+    corsaro_packet_tags_t tags;
+} PACKED corsaro_tagged_packet_header_t;
 
 /* == Protocol header structures == */
 

--- a/lib/libtrace.h.in
+++ b/lib/libtrace.h.in
@@ -416,6 +416,7 @@ typedef enum {
        TRACE_TYPE_ETSILI = 22,	/**< ETSI Lawful Intercept */
        TRACE_TYPE_PCAPNG_META = 23,	/** PCAPNG meta packet */
        TRACE_TYPE_TZSP = 24,		/** TZSP Live packets */
+       TRACE_TYPE_CORSAROTAG = 25,      /** Corsaro tagged packets */
 } libtrace_linktype_t;
 
 /** RT protocol base format identifiers.
@@ -446,6 +447,7 @@ enum base_format_t {
         TRACE_FORMAT_ETSILIVE     =21,  /**< ETSI LI over a network */
 	TRACE_FORMAT_UNKNOWN      =22,  /** Unknown format */
 	TRACE_FORMAT_TZSPLIVE	  =23,  /** TZSP */
+        TRACE_FORMAT_CORSAROTAG   =24,  /** Corsarotagger format */
 };
 
 /** RT protocol packet types */
@@ -505,6 +507,8 @@ typedef enum {
         TRACE_RT_DATA_ETSILI = TRACE_RT_DATA_SIMPLE + TRACE_FORMAT_ETSILIVE,
 	/** RT is encapsulating a tzsplive capture record */
 	TRACE_RT_DATA_TZSP = TRACE_RT_DATA_SIMPLE + TRACE_FORMAT_TZSPLIVE,
+	/** RT is encapsulating a packet tagged by corsarotagger */
+	TRACE_RT_DATA_CORSARO_TAGGED = TRACE_RT_DATA_SIMPLE + TRACE_FORMAT_CORSAROTAG,
 
 	/** As PCAP does not store the linktype with the packet, we need to 
 	 * create a separate RT type for each supported DLT, starting from

--- a/lib/lt_bswap.h
+++ b/lib/lt_bswap.h
@@ -25,6 +25,7 @@
  */
 #include <arpa/inet.h>
 #include <inttypes.h>
+#include "libtrace.h"
 /** @file
  *
  * @brief Header file containing definitions of functions and macros that deal
@@ -48,7 +49,7 @@ extern "C" {
  * @return The byteswapped 64-bit number
  *
  */
-uint64_t byteswap64(uint64_t num);
+DLLEXPORT uint64_t byteswap64(uint64_t num);
 
 /** Byteswaps a 32-bit value.
  *

--- a/lib/protocols_l2.c
+++ b/lib/protocols_l2.c
@@ -728,6 +728,7 @@ DLLEXPORT void *trace_get_layer2(const libtrace_packet_t *packet,
 		case TRACE_TYPE_PCAPNG_META:
 		case TRACE_TYPE_TZSP:
                 case TRACE_TYPE_ETSILI:
+                case TRACE_TYPE_CORSAROTAG:
 			break;
 		case TRACE_TYPE_UNKNOWN:
 		case TRACE_TYPE_CONTENT_INVALID:
@@ -768,6 +769,7 @@ DLLEXPORT void *trace_get_layer2(const libtrace_packet_t *packet,
 				case TRACE_TYPE_PCAPNG_META:
 				case TRACE_TYPE_TZSP:
                                 case TRACE_TYPE_ETSILI:
+                                case TRACE_TYPE_CORSAROTAG:
 					break;
 				case TRACE_TYPE_UNKNOWN:
 		                case TRACE_TYPE_CONTENT_INVALID:
@@ -844,6 +846,7 @@ DLLEXPORT void *trace_get_payload_from_layer2(void *link,
 		case TRACE_TYPE_PCAPNG_META:
 		case TRACE_TYPE_TZSP:
 		case TRACE_TYPE_ERF_META:
+                case TRACE_TYPE_CORSAROTAG:
 		case TRACE_TYPE_CONTENT_INVALID:
 		case TRACE_TYPE_UNKNOWN:
 			return NULL;
@@ -975,6 +978,7 @@ DLLEXPORT uint8_t *trace_get_source_mac(libtrace_packet_t *packet) {
                 case TRACE_TYPE_80211_PRISM:
                 case TRACE_TYPE_80211_RADIO:
                 case TRACE_TYPE_ETSILI:
+                case TRACE_TYPE_CORSAROTAG:
 			fprintf(stderr, "Metadata headers should already be skipped in trace_get_source_mac()\n");
 			return NULL;
         }
@@ -1032,6 +1036,7 @@ DLLEXPORT uint8_t *trace_get_destination_mac(libtrace_packet_t *packet) {
                 case TRACE_TYPE_LINUX_SLL:
                 case TRACE_TYPE_80211_PRISM:
                 case TRACE_TYPE_80211_RADIO:
+                case TRACE_TYPE_CORSAROTAG:
                 case TRACE_TYPE_ETSILI:
 			fprintf(stderr, "Metadata headers should already be skipped in trace_get_destination_mac()\n");
 			return NULL;

--- a/lib/protocols_l2.c
+++ b/lib/protocols_l2.c
@@ -671,6 +671,8 @@ DLLEXPORT void *trace_get_layer2(const libtrace_packet_t *packet,
 {
 	uint32_t dummyrem;
 	void *meta = NULL;
+        int done = 0;
+        uint32_t wire_len;
 
 	if (!packet) {
 		fprintf(stderr, "NULL packet passed into trace_get_layer2()\n");
@@ -738,52 +740,69 @@ DLLEXPORT void *trace_get_layer2(const libtrace_packet_t *packet,
 	/* If there are meta-data headers, we need to skip over them until we
 	 * find a non-meta data header and return that.
 	 */
-	for(;;) {
+	while (!done) {
 		void *nexthdr = trace_get_payload_from_meta(meta, 
 				linktype, remaining);
 		
-		if (nexthdr == NULL) {
-			switch (*linktype) {
-				/* meta points to a layer 2 header! */
-				case TRACE_TYPE_HDLC_POS:
-				case TRACE_TYPE_ETH:
-				case TRACE_TYPE_ATM:
-				case TRACE_TYPE_80211:
-				case TRACE_TYPE_NONE:
-				case TRACE_TYPE_POS:
-				case TRACE_TYPE_AAL5:
-				case TRACE_TYPE_DUCK:
-				case TRACE_TYPE_LLCSNAP:
-				case TRACE_TYPE_PPP:
-				case TRACE_TYPE_METADATA:
-				case TRACE_TYPE_NONDATA:
-				case TRACE_TYPE_OPENBSD_LOOP:
-					((libtrace_packet_t*)packet)->cached.l2_header = meta;
-					((libtrace_packet_t*)packet)->cached.l2_remaining = *remaining;
-					return meta;
-				case TRACE_TYPE_LINUX_SLL:
-				case TRACE_TYPE_80211_RADIO:
-				case TRACE_TYPE_80211_PRISM:
-				case TRACE_TYPE_PFLOG:
-				case TRACE_TYPE_ERF_META:
-				case TRACE_TYPE_PCAPNG_META:
-				case TRACE_TYPE_TZSP:
-                                case TRACE_TYPE_ETSILI:
-                                case TRACE_TYPE_CORSAROTAG:
-					break;
-				case TRACE_TYPE_UNKNOWN:
-		                case TRACE_TYPE_CONTENT_INVALID:
-					return NULL;
-			}
-			
-			/* Otherwise, we must have hit the end of the packet */
-			return NULL;
-		}
-	 
-	 	
-		meta = nexthdr;
+		if (nexthdr != NULL) {
+                        meta = nexthdr;
+                        continue;
+                }
+
+                switch (*linktype) {
+                        /* meta points to a layer 2 header! */
+                        case TRACE_TYPE_HDLC_POS:
+                        case TRACE_TYPE_ETH:
+                        case TRACE_TYPE_ATM:
+                        case TRACE_TYPE_80211:
+                        case TRACE_TYPE_NONE:
+                        case TRACE_TYPE_POS:
+                        case TRACE_TYPE_AAL5:
+                        case TRACE_TYPE_DUCK:
+                        case TRACE_TYPE_LLCSNAP:
+                        case TRACE_TYPE_PPP:
+                        case TRACE_TYPE_METADATA:
+                        case TRACE_TYPE_NONDATA:
+                        case TRACE_TYPE_OPENBSD_LOOP:
+                                done = 1;
+                                break;
+                        case TRACE_TYPE_LINUX_SLL:
+                        case TRACE_TYPE_80211_RADIO:
+                        case TRACE_TYPE_80211_PRISM:
+                        case TRACE_TYPE_PFLOG:
+                        case TRACE_TYPE_ERF_META:
+                        case TRACE_TYPE_PCAPNG_META:
+                        case TRACE_TYPE_TZSP:
+                        case TRACE_TYPE_ETSILI:
+                        case TRACE_TYPE_CORSAROTAG:
+                                meta = nexthdr;  // should never hit this?
+                                break;
+                        case TRACE_TYPE_UNKNOWN:
+                        case TRACE_TYPE_CONTENT_INVALID:
+                                return NULL;
+                }
 	}
 
+        /* L2 remaining should never exceed wire length, to avoid treating
+         * capture padding as genuine packet content.
+         *
+         * For example, in Auck 4 there is a trace where the IP header
+         * length is incorrect (24 bytes) followed by a 20 byte TCP
+         * header. Total IP length is 40 bytes. As a result, the
+         * legacyatm padding gets treated as the "missing" bytes of
+         * the TCP header, which isn't the greatest. We're probably
+         * better off returning an incomplete TCP header in that case.
+         */
+
+        wire_len = (uint32_t) trace_get_wire_length(packet);
+        if (wire_len > 0 && wire_len < *remaining) {
+                *remaining = wire_len;
+        }
+
+        ((libtrace_packet_t*)packet)->cached.l2_header = meta;
+        ((libtrace_packet_t*)packet)->cached.l2_remaining = *remaining;
+
+        return meta;
 }
 
 DLLEXPORT

--- a/lib/trace.c
+++ b/lib/trace.c
@@ -1190,8 +1190,6 @@ DLLEXPORT int trace_write_packet(libtrace_out_t *libtrace, libtrace_packet_t *pa
 /* Get a pointer to the first byte of the packet payload */
 DLLEXPORT void *trace_get_packet_buffer(const libtrace_packet_t *packet,
 		libtrace_linktype_t *linktype, uint32_t *remaining) {
-	int cap_len;
-	int wire_len;
         libtrace_linktype_t ltype;
 
 	if (!packet) {
@@ -1212,42 +1210,7 @@ DLLEXPORT void *trace_get_packet_buffer(const libtrace_packet_t *packet,
         }
 
 	if (remaining) {
-		/* I think we should choose the minimum of the capture and
-		 * wire lengths to be the "remaining" value. If the packet has
-		 * been padded to increase the capture length, we don't want
-		 * to allow subsequent protocol decoders to consider the
-		 * padding as part of the packet.
-		 *
-		 * For example, in Auck 4 there is a trace where the IP header
-		 * length is incorrect (24 bytes) followed by a 20 byte TCP
-		 * header. Total IP length is 40 bytes. As a result, the
-		 * legacyatm padding gets treated as the "missing" bytes of
-		 * the TCP header, which isn't the greatest. We're probably
-		 * better off returning an incomplete TCP header in that case.
-		 */
-
-		cap_len = trace_get_capture_length(packet);
-		wire_len = trace_get_wire_length(packet);
-
-		if (!(cap_len >= 0)) {
-			fprintf(stderr, "Was expecting capture length of atleast 0 in trace_get_packet_buffer()\n");
-			return NULL;
-		}
-
-		/* There is the odd corrupt packet, e.g. in IPLS II, that have
-		 * massively negative wire lens. We could assert fail here on
-		 * them, but we could at least try the capture length instead.
-		 *
-		 * You may still run into problems if you try to write that
-		 * packet, but at least reading should work OK.
-		 */
-		if (wire_len < 0)
-			*remaining = cap_len;
-		else if (wire_len < cap_len)
-			*remaining = wire_len;
-		else
-			*remaining = cap_len;
-		/* *remaining = trace_get_capture_length(packet); */
+		*remaining = trace_get_capture_length(packet);
 	}
 	return (void *) packet->payload;
 }

--- a/libpacketdump/Makefile.am
+++ b/libpacketdump/Makefile.am
@@ -71,6 +71,9 @@ endif
 #23: PCAPNG
 BIN_PROTOCOLS+=link_23.la
 
+#25: Corsaro tags
+BIN_PROTOCOLS+=link_25.la
+
 # Decoders for various ethertypes (in decimal)
 # IPv4
 BIN_PROTOCOLS+=eth_0.la
@@ -150,6 +153,7 @@ if HAVE_WANDDER
 link_22_la_LDFLAGS=$(modflags) 
 endif
 link_23_la_LDFLAGS=$(modflags)
+link_25_la_LDFLAGS=$(modflags)
 eth_0_la_LDFLAGS=$(modflags)
 eth_2048_la_LDFLAGS=$(modflags)
 eth_2054_la_LDFLAGS=$(modflags)

--- a/libpacketdump/link_25.c
+++ b/libpacketdump/link_25.c
@@ -1,0 +1,66 @@
+#include "libtrace.h"
+#include "libpacketdump.h"
+#include "format_ndag.h"
+#include "lt_bswap.h"
+
+DLLEXPORT void decode(int link_type UNUSED, const char *packet, unsigned len) {
+
+	corsaro_packet_tags_t *tags;
+	uint32_t prov_used;
+        uint64_t filterbits;
+        int i;
+
+	tags = (corsaro_packet_tags_t *)packet;
+
+	prov_used = ntohl(tags->providers_used);
+        filterbits = bswap_be_to_host64(tags->filterbits);
+
+	printf(" CorsaroTags: Protocol: %u  Source Port: %u  Dest Port: %u\n",
+			tags->protocol, ntohs(tags->src_port),
+			ntohs(tags->dest_port));
+	printf(" CorsaroTags: Flowtuple hash: %u\n", ntohl(tags->ft_hash));
+	if (prov_used & (1 << NDAG_IPMETA_PROVIDER_MAXMIND)) {
+		printf(" CorsaroTags: Maxmind Continent: %c%c   Country: %c%c\n",
+				(unsigned char)(tags->maxmind_continent & 0xff),
+				(unsigned char)(tags->maxmind_continent >> 8),
+				(unsigned char)(tags->maxmind_country & 0xff),
+				(unsigned char)(tags->maxmind_country >> 8)
+		);
+	}
+	if (prov_used & (1 << NDAG_IPMETA_PROVIDER_NETACQ_EDGE)) {
+		printf(" CorsaroTags: Netacq-Edge Continent: %c%c   Country: %c%c\n",
+				(unsigned char)(tags->netacq_continent & 0xff),
+				(unsigned char)(tags->netacq_continent >> 8),
+				(unsigned char)(tags->netacq_country & 0xff),
+				(unsigned char)(tags->netacq_country >> 8)
+		);
+                printf(" CorsaroTags: Netacq-Edge Region Code: %u\n",
+                                ntohs(tags->netacq_region));
+                printf(" CorsaroTags: Netacq-Edge Polygon Ids: ");
+                for (i = 0; i < MAX_NETACQ_POLYGONS; i++) {
+                        if (tags->netacq_polygon[i] == 0) {
+                                break;
+                        }
+                        printf("%u ", ntohl(tags->netacq_polygon[i]));
+                }
+                printf("\n");
+
+	}
+        if (prov_used & (1 << NDAG_IPMETA_PROVIDER_PFX2AS)) {
+                printf(" CorsaroTags: Source ASN: %u\n",
+                                ntohl(tags->prefixasn));
+        }
+
+        printf(" CorsaroTags: Filters: ");
+        /* Let's just cover the high-level filters here */
+        printf("%s%s%s%s\n",
+                        (filterbits & 0x01) ? "Spoofed " : "Not-Spoofed ",
+                        (filterbits & 0x02) ? "Erratic " : "Not-Erratic ",
+                        (filterbits & 0x04) ? "Not-Routable " : "Routable ",
+                        (filterbits & 0x08) ? "LSScan ": "");
+
+        if (len > sizeof(corsaro_packet_tags_t)) {
+                decode_next(packet + sizeof(corsaro_packet_tags_t),
+                        len - sizeof(corsaro_packet_tags_t), "link", 2);
+        }
+}


### PR DESCRIPTION
The corsarotagger tool adds a special layer of meta-data to a captured packet and then publishes it to downstream clients using the nDAG protocol.

The meta-data can be accessed using `trace_get_packet_meta()` and casting to `corsaro_packet_tags_t` (the `lib/format_ndag.h` header may be required to do this). Otherwise, `trace_get_layer2()` will jump straight to the start of the captured packet itself. Note that capture length for these packets will include the meta-data structure.

This PR also includes a fix for an issue discovered during testing this new support, whereby `trace_get_packet_buffer()` could truncate packets that have had meta-data added to them that was not present on the wire (and is therefore not part of the wire length). Now meta-data is excluded from any potential padding-removal truncation that libtrace might do to a packet.