### PR TITLE
Add support for dpdk 19.11 as included on Ubuntu 20.04 plus many other fixes

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -514,7 +514,7 @@ AC_ARG_WITH(dpdk,
 
 libtrace_dpdk=false
 if test "$want_dpdk" != no; then
-
+	dpdk_found=0
 	# So instead simply check for existence
 	if test "$dpdk_found" = 0 -a "$RTE_SDK" != ""; then
 		AC_CHECK_FILE("$RTE_SDK/$RTE_TARGET/lib/libdpdk.so", dpdk_found="dpdk", dpdk_found=0)
@@ -562,16 +562,16 @@ if test "$want_dpdk" != no; then
 	# without which we cannot load PCI devices.
 	# So we always use PKG_CHECK_MODULES_STATIC here, even for dynamic linking.
 	#
-        PKG_CHECK_MODULES_STATIC([DPDK], [libdpdk >= 18], [pkgconf_dpdk_found="yes"],
-                [pkgconf_dpdk_found="no"])
-        if test "x$pkgconf_dpdk_found" = "xyes"; then
+        if test "$dpdk_found" = 0; then
+                PKG_CHECK_MODULES_STATIC([DPDK], [libdpdk >= 18], [pkgconf_dpdk_found="yes"],
+                                         [pkgconf_dpdk_found="no"])
+        fi
+        if test "$dpdk_found" = 0 -a "x$pkgconf_dpdk_found" = "xyes"; then
                 LIBTRACE_LIBS="$LIBTRACE_LIBS -Wl,--no-as-needed $(echo $DPDK_LIBS | sed 's/ -l/ -Wl,-l/g')"
 		AC_MSG_NOTICE([LIBS = $DPDK_LIBS])
                 ADD_INCLS="$ADD_INCLS $DPDK_CFLAGS"
                 AC_MSG_NOTICE([Building against system DPDK])
                 dpdk_found=pkgconfig
-        else
-                dpdk_found=0
         fi
 
 	if test "$dpdk_found" = 0 -a "$RTE_SDK" = ""; then

--- a/configure.in
+++ b/configure.in
@@ -560,15 +560,21 @@ if test "$want_dpdk" != no; then
 	# 3) The package-cfg for Ubuntu 20.02 (DPDK 19.11) is wrong for dynamic
 	# libraries and is missing important libraries like rte_bus_pci,
 	# without which we cannot load PCI devices.
-	# So we always use PKG_CHECK_MODULES_STATIC here, even for dynamic linking.
+	# So we always use pkg-config --static here, even for dynamic linking.
+	# Note the nicer PKG_CHECK_MODULES_STATIC macro doesn't exist in older
+	# distributions.
 	#
         if test "$dpdk_found" = 0; then
-                PKG_CHECK_MODULES_STATIC([DPDK], [libdpdk >= 18], [pkgconf_dpdk_found="yes"],
-                                         [pkgconf_dpdk_found="no"])
+                PKG_PROG_PKG_CONFIG
+                pkg_config_old="$PKG_CONFIG"
+                PKG_CONFIG="$PKG_CONFIG --static"
+                PKG_CHECK_MODULES([DPDK], [libdpdk >= 18], [pkgconf_dpdk_found="yes"],
+                                  [pkgconf_dpdk_found="no"])
+                PKG_CONFIG="$pkg_config_old"
         fi
         if test "$dpdk_found" = 0 -a "x$pkgconf_dpdk_found" = "xyes"; then
                 LIBTRACE_LIBS="$LIBTRACE_LIBS -Wl,--no-as-needed $(echo $DPDK_LIBS | sed 's/ -l/ -Wl,-l/g')"
-		AC_MSG_NOTICE([LIBS = $DPDK_LIBS])
+                AC_MSG_NOTICE([Pkg config found DPDK libs = $DPDK_LIBS])
                 ADD_INCLS="$ADD_INCLS $DPDK_CFLAGS"
                 AC_MSG_NOTICE([Building against system DPDK])
                 dpdk_found=pkgconfig

--- a/configure.in
+++ b/configure.in
@@ -572,9 +572,6 @@ if test "$want_dpdk" != no; then
 
         if test "$dpdk_found" != 0; then
 		AC_DEFINE(HAVE_DPDK,1,[conditional for building with DPDK live capture support])
-                LIBS="$LIBTRACE_LIBS"
-                AC_CHECK_FUNC(rte_devargs_add, [AC_DEFINE(HAVE_DPDK18,1,using dpdk version 18 or later)])
-                LIBS=""
                 libtrace_dpdk=true
         fi
 

--- a/configure.in
+++ b/configure.in
@@ -515,18 +515,6 @@ AC_ARG_WITH(dpdk,
 libtrace_dpdk=false
 if test "$want_dpdk" != no; then
 
-        PKG_CHECK_MODULES([DPDK], [libdpdk >= 18], [pkgconf_dpdk_found="yes"],
-                [pkgconf_dpdk_found="no"])
-        if test "x$pkgconf_dpdk_found" = "xyes"; then
-                LIBTRACE_LIBS="$LIBTRACE_LIBS $DPDK_LIBS"
-                ADD_INCLS="$ADD_INCLS $DPDK_CFLAGS"
-                AC_MSG_NOTICE([Building against system DPDK])
-                dpdk_found=pkgconfig
-        else
-                dpdk_found=0
-        fi
-
-
 	# So instead simply check for existence
 	if test "$dpdk_found" = 0 -a "$RTE_SDK" != ""; then
 		AC_CHECK_FILE("$RTE_SDK/$RTE_TARGET/lib/libdpdk.so", dpdk_found="dpdk", dpdk_found=0)
@@ -549,6 +537,42 @@ if test "$want_dpdk" != no; then
 		LIBTRACE_LIBS="$LIBTRACE_LIBS -Wl,--whole-archive -Wl,-l$dpdk_found -Wl,--no-whole-archive -Wl,-lm"
 
 	fi
+
+	# Find the DPDK system package
+	# We do this last to allow RTE_SDK to override the system library
+	#
+	# Dynamic linking against the system's version of DPDK is never easy:
+	#
+	# 1) On Ubuntu the linker has --as-needed set by default, this means
+	# any library which libtrace doesn't directly reference a method from
+	# is not listed as a dependency to libtrace.so. This causes problems
+	# for DPDK, DPDK uses .init or .ctors to patch drivers etc into its
+	# global structures. So libraries need to be loaded simply to register
+	# themselves.
+	#
+	# 2) The answer to this is --no-as-needed, a positional argument, which
+	# applies to all following arguments/libs. However, libtool *helpfully*
+	# reorganises the arguments we give it before giving them to the linker.
+	# To avoid this we need to prefix all libraries with -Wl,-lxxx, so
+	# libtool leaves them be.
+	# Hence the ugly sed hack, TODO find something nicer.
+	#
+	# 3) The package-cfg for Ubuntu 20.02 (DPDK 19.11) is wrong for dynamic
+	# libraries and is missing important libraries like rte_bus_pci,
+	# without which we cannot load PCI devices.
+	# So we always use PKG_CHECK_MODULES_STATIC here, even for dynamic linking.
+	#
+        PKG_CHECK_MODULES_STATIC([DPDK], [libdpdk >= 18], [pkgconf_dpdk_found="yes"],
+                [pkgconf_dpdk_found="no"])
+        if test "x$pkgconf_dpdk_found" = "xyes"; then
+                LIBTRACE_LIBS="$LIBTRACE_LIBS -Wl,--no-as-needed $(echo $DPDK_LIBS | sed 's/ -l/ -Wl,-l/g')"
+		AC_MSG_NOTICE([LIBS = $DPDK_LIBS])
+                ADD_INCLS="$ADD_INCLS $DPDK_CFLAGS"
+                AC_MSG_NOTICE([Building against system DPDK])
+                dpdk_found=pkgconfig
+        else
+                dpdk_found=0
+        fi
 
 	if test "$dpdk_found" = 0 -a "$RTE_SDK" = ""; then
 		AC_MSG_NOTICE([No RTE_SDK given, checking for system dpdk-dev package])

--- a/lib/format_dpdk.c
+++ b/lib/format_dpdk.c
@@ -1457,10 +1457,12 @@ static int dpdk_start_streams(struct dpdk_format_data_t *format_data,
 		 * Only used for TX */
 		rte_eth_link_get(format_data->port, &link_info);
 		format_data->link_speed = link_info.link_speed;
-	} else {
-		rte_eth_link_get_nowait(format_data->port, &link_info);
-		format_data->link_speed = link_info.link_speed;
+		// Wait an extra 0.5s, as the link has just come up and
+		// the receiver might not actually be ready yet.
+		usleep(500000);
 	}
+	rte_eth_link_get_nowait(format_data->port, &link_info);
+	format_data->link_speed = link_info.link_speed;
 #if DEBUG
 	fprintf(stderr, "Libtrace DPDK: Link status is %d %d %d\n",
 		(int) link_info.link_status,

--- a/lib/format_dpdk.c
+++ b/lib/format_dpdk.c
@@ -435,6 +435,7 @@ static inline int dpdk_init_environment(char * uridata, struct dpdk_format_data_
 			"-l", master_lcore_id, /* Give DPDK only the master lcore */
 	                "--proc-type", "auto",
 	                "--file-prefix", mem_map,
+			"--no-shconf", "--huge-unlink",
 	                "-m", "512",
 #if DPDK_USE_LOG_LEVEL
 #	if DEBUG

--- a/lib/format_dpdk.c
+++ b/lib/format_dpdk.c
@@ -1199,7 +1199,7 @@ static int dpdk_start_streams(struct dpdk_format_data_t *format_data,
 
 #if GET_MAC_CRC_CHECKSUM
 		/* This is additional overhead so make sure we allow space for this */
-		format_data->snaplen += ETHER_CRC_LEN;
+		format_data->snaplen += RTE_ETHER_CRC_LEN;
 #endif
 #if HAS_HW_TIMESTAMPS_82580
 		format_data->snaplen += sizeof(struct hw_timestamp_82580);
@@ -1627,7 +1627,7 @@ static int dpdk_write_packet(libtrace_out_t *trace,
 	/* Check for a checksum and remove it */
 	if (trace_get_link_type(packet) == TRACE_TYPE_ETH &&
 	    wirelen == caplen)
-		caplen -= ETHER_CRC_LEN;
+		caplen -= RTE_ETHER_CRC_LEN;
 
 	m_buff[0] = rte_pktmbuf_alloc(FORMAT(trace)->pktmbuf_pool);
 	if (m_buff[0] == NULL) {
@@ -1739,7 +1739,7 @@ static int dpdk_get_wire_length (const libtrace_packet_t *packet) {
 		return org_cap_size;
 	} else {
 		/* DPDK packets are always TRACE_TYPE_ETH packets */
-		return org_cap_size + ETHER_CRC_LEN;
+		return org_cap_size + RTE_ETHER_CRC_LEN;
 	}
 }
 
@@ -1793,7 +1793,7 @@ static inline uint32_t calculate_wire_time(struct dpdk_format_data_t* format_dat
 # if GET_MAC_CRC_CHECKSUM
 	wire_time = ((pkt_size + 20) * 8000);
 # else
-	wire_time = ((pkt_size + 20 + ETHER_CRC_LEN) * 8000);
+	wire_time = ((pkt_size + 20 + RTE_ETHER_CRC_LEN) * 8000);
 # endif
 
 	/* Division is really slow and introduces a pipeline stall
@@ -1898,8 +1898,8 @@ static inline void dpdk_ready_pkts(libtrace_t *libtrace,
 
 #if GET_MAC_CRC_CHECKSUM
 		/* Add back in the CRC sum */
-		rte_pktmbuf_pkt_len(pkt) += ETHER_CRC_LEN;
-		rte_pktmbuf_data_len(pkt) += ETHER_CRC_LEN;
+		rte_pktmbuf_pkt_len(pkt) += RTE_ETHER_CRC_LEN;
+		rte_pktmbuf_data_len(pkt) += RTE_ETHER_CRC_LEN;
 		hdr->flags |= INCLUDES_CHECKSUM;
 #endif
 

--- a/lib/format_dpdk.c
+++ b/lib/format_dpdk.c
@@ -2326,6 +2326,18 @@ static void dpdk_help(void) {
 	printf("\n");
 }
 
+static void dpdk_vdev_help(void) {
+	printf("dpdk vdev format module: %s (%d) \n", rte_version(), RTE_VERSION);
+	printf("Supported input and output URIs:\n");
+	printf("\tdpdkvdev:<driver><id>,[key=val, ...]-<coreid>\n");
+	printf("\tThe -<coreid> is optional\n");
+	printf("\tEverything before the '-' is given to DPDK in a --vdev argument\n");
+	printf("\tSee the DPDK documentation for the valid values\n");
+	printf("\t e.g. dpdkvdev:net_pcap0,iface=veth0\n");
+	printf("\t e.g. dpdkvdev:net_tap0,iface=tap0\n");
+	printf("\n");
+}
+
 static struct libtrace_format_t dpdk = {
 	"dpdk",
 	"$Id$",
@@ -2420,7 +2432,7 @@ static struct libtrace_format_t dpdk_vdev = {
 	dpdk_get_stats,                     /* get_statistics */
 	NULL,                               /* get_fd */
 	dpdk_trace_event,                   /* trace_event */
-	dpdk_help,                          /* help */
+	dpdk_vdev_help,                     /* help */
 	NULL,                               /* next pointer */
 	{true, 8},                          /* Live, NICs typically have 8 threads */
 	dpdk_pstart_input,                  /* pstart_input */

--- a/lib/format_dpdk.c
+++ b/lib/format_dpdk.c
@@ -2141,6 +2141,8 @@ static libtrace_linktype_t dpdk_get_link_type (const libtrace_packet_t *packet U
 
 static libtrace_direction_t dpdk_get_direction (const libtrace_packet_t *packet) {
 	struct dpdk_addt_hdr * hdr = get_addt_hdr(packet);
+	if (hdr->direction == (uint8_t) -1)
+		return TRACE_DIR_UNKNOWN;
 	return (libtrace_direction_t) hdr->direction;
 }
 

--- a/lib/format_dpdk.h
+++ b/lib/format_dpdk.h
@@ -183,6 +183,10 @@ typedef uint8_t portid_t;
   #define RTE_ETHER_CRC_LEN ETHER_CRC_LEN
 #endif
 
+#ifndef RTE_ETHER_MAX_LEN
+  #define RTE_ETHER_MAX_LEN ETHER_MAX_LEN
+#endif
+
 /* The default size of memory buffers to use - This is the max size of standard
  * ethernet packet less the size of the MAC CHECKSUM, rounded up to the
  * next power of 2, plus the RTE_PKTMBUF_HEADROOM. */

--- a/lib/format_dpdk.h
+++ b/lib/format_dpdk.h
@@ -154,7 +154,6 @@ typedef uint8_t portid_t;
 #include <rte_mbuf.h>
 #include <rte_launch.h>
 #include <rte_lcore.h>
-#include <rte_per_lcore.h>
 #include <rte_cycles.h>
 #include <pthread.h>
 #ifdef __FreeBSD__

--- a/lib/format_dpdk.h
+++ b/lib/format_dpdk.h
@@ -178,6 +178,12 @@ typedef uint8_t portid_t;
         #define ETH_SPEED_NUM_40G ETH_LINK_SPEED_40G
 #endif
 
+/* https://github.com/DPDK/dpdk/commit/35b2d13 19.08-rc1
+ * renames ETHER_CRC_LEN -> RTE_ETHER_CRC_LEN */
+#ifndef RTE_ETHER_CRC_LEN
+  #define RTE_ETHER_CRC_LEN ETHER_CRC_LEN
+#endif
+
 /* The default size of memory buffers to use - This is the max size of standard
  * ethernet packet less the size of the MAC CHECKSUM, rounded up to the
  * next power of 2, plus the RTE_PKTMBUF_HEADROOM. */

--- a/lib/format_dpdk.h
+++ b/lib/format_dpdk.h
@@ -315,7 +315,8 @@ int dpdk_pstart_input (libtrace_t *libtrace);
 int dpdk_start_input (libtrace_t *libtrace);
 int dpdk_config_input (libtrace_t *libtrace,
                 trace_option_t option, void *data);
-int dpdk_init_input (libtrace_t *libtrace);
+int dpdk_init_input_pci (libtrace_t *libtrace);
+int dpdk_init_input_vdev (libtrace_t *libtrace);
 int dpdk_pause_input(libtrace_t * libtrace);
 int dpdk_fin_input(libtrace_t * libtrace);
 int dpdk_read_packet (libtrace_t *libtrace, libtrace_packet_t *packet);

--- a/lib/format_dpdk.h
+++ b/lib/format_dpdk.h
@@ -129,12 +129,12 @@ typedef uint16_t portid_t;
 typedef uint8_t portid_t;
 #endif
 
-#ifndef HAVE_DPDK18             /* XXX would do a specific version check here
-                                 * but can't be bothered tracking down
-                                 * exactly when these functions changed names.
-                                 */
-#define rte_devargs_add rte_eal_devargs_add
-#define rte_eth_dev_count_avail rte_eth_dev_count
+/* 18.05-rc1 renames rte_eth_dev functions to rte_dev
+ * See https://doc.dpdk.org/guides-18.02/rel_notes/deprecation.html
+ */
+#if RTE_VERSION < RTE_VERSION_NUM(18, 5, 0, 1)
+  #define rte_devargs_add rte_eal_devargs_add
+  #define rte_eth_dev_count_avail rte_eth_dev_count
 #endif
 
 

--- a/lib/format_linux_common.c
+++ b/lib/format_linux_common.c
@@ -518,11 +518,15 @@ int linuxcommon_pregister_thread(libtrace_t *libtrace,
                                  bool reading) {
 	if (reading) {
 		/* XXX TODO remove this oneday make sure hasher thread still works */
-		struct linux_per_stream_t *stream;
-		stream = libtrace_list_get_index(FORMAT_DATA->per_stream,
-		                                 t->perpkt_num)->data;
-		t->format_data = stream;
-		if (!stream) {
+		libtrace_list_node_t *item;
+		item = libtrace_list_get_index(FORMAT_DATA->per_stream,
+		                               t->perpkt_num);
+		if (item) {
+			t->format_data = item->data;
+		} else {
+			t->format_data = NULL;
+		}
+		if (!t->format_data) {
 			/* This should never happen and indicates an
 			 * internal libtrace bug */
 			trace_set_err(libtrace, TRACE_ERR_INIT_FAILED,

--- a/test/do-live-tests.sh
+++ b/test/do-live-tests.sh
@@ -76,6 +76,10 @@ $@"
 	fi
 }
 
+# Don't test pcapint as it only has a 30 packets buffer and
+# it always drops packets and fails to capture all 100
+declare -a read_formats=("int:veth1" "ring:veth1" "dpdkvdev:net_pcap0,iface=veth1")
+
 for r in "${read_formats[@]}"
 do
 	do_parallel_test ./test-format-parallel "$r"

--- a/test/do-live-tests.sh
+++ b/test/do-live-tests.sh
@@ -21,12 +21,15 @@ libdir=../lib/.libs:../libpacketdump/.libs
 export LD_LIBRARY_PATH="$libdir:/usr/local/lib/"
 export DYLD_LIBRARY_PATH="${libdir}"
 
-declare -a formats=("pcapint" "int" "ring")
+declare -a formats=("pcapint" "int" "ring" "dpdkvdev")
 
 for a in "${formats[@]}"
 do
 	for b in "${formats[@]}"
 	do
+		if [[ "$a" == "dpdkvdev" && "$b" == dpdkvdev ]]; then
+			continue
+		fi
 		echo
 		echo ./test-live "$a" "$b"
 		do_test ./test-live "$a" "$b"

--- a/test/do-live-tests.sh
+++ b/test/do-live-tests.sh
@@ -2,6 +2,8 @@
 
 OK=0
 FAIL=""
+PARALLEL_OK=0
+PARALLEL_FAIL=""
 
 do_test() {
 	if $@; then
@@ -17,28 +19,77 @@ if [[ -z "$GOT_NETNS" ]]; then
 	exit 0
 fi
 
-libdir=../lib/.libs:../libpacketdump/.libs
-export LD_LIBRARY_PATH="$libdir:/usr/local/lib/"
-export DYLD_LIBRARY_PATH="${libdir}"
+# If we already have LD_LIBRARY_PATH set assume it correctly
+# points to libtrace we want to test.
+if [[ -z "$LD_LIBRARY_PATH" ]]; then
+	libdir=../lib/.libs:../libpacketdump/.libs
+	export LD_LIBRARY_PATH="$libdir:/usr/local/lib/"
+	export DYLD_LIBRARY_PATH="${libdir}"
+fi
 
-declare -a formats=("pcapint" "int" "ring" "dpdkvdev")
+declare -a write_formats=("pcapint:veth0" "int:veth0" "ring:veth0" "dpdkvdev:net_pcap0,iface=veth0")
+declare -a read_formats=("pcapint:veth1" "int:veth1" "ring:veth1" "dpdkvdev:net_pcap0,iface=veth1")
 
-for a in "${formats[@]}"
+echo "Running single threaded API tests"
+for w in "${write_formats[@]}"
 do
-	for b in "${formats[@]}"
+	for r in "${read_formats[@]}"
 	do
-		if [[ "$a" == "dpdkvdev" && "$b" == dpdkvdev ]]; then
+		if [[ "$w" == dpdkvdev* && "$r" == dpdkvdev* ]]; then
 			continue
 		fi
 		echo
-		echo ./test-live "$a" "$b"
-		do_test ./test-live "$a" "$b"
+		echo ./test-live "$w" "$r"
+		do_test ./test-live "$w" "$r"
 		echo
-		echo ./test-live-snaplen "$a" "$b"
-		do_test ./test-live-snaplen "$a" "$b"
+		echo ./test-live-snaplen "$w" "$r"
+		do_test ./test-live-snaplen "$w" "$r"
 	done
 done
 
 echo
-echo "Tests passed: $OK"
-echo "Tests failed: $FAIL"
+echo "Single threaded API tests passed: $OK"
+echo "Single threaded API tests failed: $FAIL"
+echo
+
+echo
+echo "Running parallel API tests"
+echo
+do_parallel_test() {
+	echo
+	echo "$@"
+	timeout 5 "$@" &
+	my_pid=$!
+	sleep 2  # Ensure we've had time to setup, particularly dpdk
+	if ! ./test-live "int:veth0"; then
+		echo "TEST ERROR: ./test-live int:veth0 (couldn't generate packets)"
+		exit -1
+	fi
+	sleep 1  # Wait for all packets to be received
+	kill -SIGINT $my_pid
+
+	if wait $my_pid; then
+		PARALLEL_OK=$[ $PARALLEL_OK + 1 ]
+	else
+		PARALLEL_FAIL="$PARALLEL_FAIL
+$@"
+	fi
+}
+
+for r in "${read_formats[@]}"
+do
+	do_parallel_test ./test-format-parallel "$r"
+	do_parallel_test ./test-format-parallel-hasher "$r"
+	# TODO fix test-format-parallel-reporter for live input
+	# do_parallel_test ./test-format-parallel-reporter "$r"
+	do_parallel_test ./test-format-parallel-singlethreaded "$r"
+	do_parallel_test ./test-format-parallel-singlethreaded-hasher "$r"
+
+done
+
+echo
+echo "Single threaded API tests passed: $OK"
+echo "Single threaded API tests failed: $FAIL"
+echo
+echo "Parallel API tests passed: $PARALLEL_OK"
+echo "Parallel API tests failed: $PARALLEL_FAIL"

--- a/test/do-test-build-dpdk-live.sh
+++ b/test/do-test-build-dpdk-live.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Run after ./do-test-build-dpdk
+# Checks that versions of the DPDK library compile successfully
+# Ensure that all DPDK requirements are installed on the system
+
+TEST_DIR=$(pwd)
+LIBTRACE_DIR="$TEST_DIR"/../
+DOWNLOAD_DIR="$TEST_DIR"/DPDK_source
+BUILD_DIR="$TEST_DIR"/DPDK_builds
+
+cd "$BUILD_DIR"
+for dpdk_build in $(ls -d */)
+do
+	echo "$dpdk_build"
+	cd "$TEST_DIR"
+	export LD_LIBRARY_PATH="$BUILD_DIR/$dpdk_build/lib"
+	./do-live-tests.sh
+done

--- a/test/do-test-build-dpdk.sh
+++ b/test/do-test-build-dpdk.sh
@@ -2,23 +2,38 @@
 # Checks that versions of the DPDK library compile successfully
 # Ensure that all DPDK requirements are installed on the system
 
+echo
+echo "Note the system package of DPDK sometimes might take priority"
+echo "over these static builds. The resulting error looks like this:"
+echo "/usr/bin/ld: .libs/libtrace.so.4.1.5: version node not found for symbol rte_lpm6_add@DPDK_2.0"
+echo "/usr/bin/ld: failed to set dynamic section sizes: bad value"
+echo
+
 TEST_DIR=$(pwd)
 LIBTRACE_DIR="$TEST_DIR"/../
-DPDK_DOWNLOAD_PATH=http://wand.nz/~rjs51/dpdk/
+DPDK_DOWNLOAD_PATH=https://wand.nz/~rsanger/dpdk/
 DOWNLOAD_DIR="$TEST_DIR"/DPDK_source
 BUILD_DIR="$TEST_DIR"/DPDK_builds
 BUILD_THREADS=9
 
 
+SUCCESSFUL=""
+DPDK_FAILED=""
+LIBTRACE_FAILED=""
 OK=0
 FAIL=""
+ERROR_MSG=""
 
 do_test() {
-	if "$@"; then
+	"$@"
+	ret=$?
+	if [ $ret = 0 ]; then
 		OK=$[ $OK + 1]
+		return $ret
 	else
 		FAIL="$FAIL
-$@"
+$ERROR_MSG ($@)"
+		return $ret
 	fi
 }
 
@@ -33,6 +48,7 @@ declare -a dpdk_versions=(
 	"dpdk-16.07.2.tar.gz"
 	"dpdk-16.11.6.tar.gz"
 	)
+
 # Versions to check stretch linux 4.9
 declare -a dpdk_versions=(
 	"dpdk-2.2.0.tar.gz"
@@ -46,6 +62,33 @@ declare -a dpdk_versions=(
 	"dpdk-18.02.1.tar.gz"
 	)
 
+# Versions to check buster linux 4.19
+# A full list of DPDK versions to check in buster
+declare -a dpdk_versions=(
+	"dpdk-16.11.11.tar.gz"
+	"dpdk-17.05.2.tar.gz"
+	"dpdk-17.08.2.tar.gz"
+	"dpdk-17.11.10.tar.gz"
+	"dpdk-18.02.2.tar.gz"
+	"dpdk-18.05.1.tar.gz"
+	"dpdk-18.08.1.tar.gz"
+	"dpdk-18.11.7.tar.gz"
+	"dpdk-19.02.tar.gz"
+	"dpdk-19.05.tar.gz"
+	"dpdk-19.08.2.tar.gz"
+	"dpdk-19.11.1.tar.gz"
+	"dpdk-20.02.tar.gz"
+	)
+
+# Versions to check buster linux 4.19
+# Main LTS releases to check in buster
+declare -a dpdk_versions=(
+	"dpdk-16.11.11.tar.gz"
+	"dpdk-17.11.10.tar.gz"
+	"dpdk-18.11.7.tar.gz"
+	"dpdk-19.11.1.tar.gz"
+	"dpdk-20.02.tar.gz"
+	)
 
 mkdir "$DOWNLOAD_DIR" > /dev/null 2>&1
 if [ ! -d "$DOWNLOAD_DIR" ]; then
@@ -61,10 +104,14 @@ do
 		wget "$DPDK_DOWNLOAD_PATH"/"$dpdk_version" > /dev/null
 		if [ $? -ne 0 ]; then
 			echo "ERROR: Failed to download" "$dpdk_version"
+			DPDK_FAILED="$DPDK_FAILED
+Failed to download $dpdk_version"
 		else
 			tar xf "$dpdk_version"
 			if [ $? -ne 0 ]; then
 				echo "ERROR: Failed to extract" "$dpdk_version"
+				DPDK_FAILED="$DPDK_FAILED
+Failed to extract $dpdk_version"
 			fi
 		fi
 	fi
@@ -80,16 +127,32 @@ for dpdk_build in $(ls -d */)
 do
 	cd "$dpdk_build"
 	echo "Building $dpdk_build - this might take some time"
+	if [ -f build_success ]; then
+		echo "	Already built - skipping"
+		cd ..
+		continue
+	fi
+	ERROR_MSG="Building $dpdk_build"
 	do_test make install T=x86_64-native-linuxapp-gcc \
 		             CONFIG_RTE_BUILD_COMBINE_LIBS=y \
 			     CONFIG_RTE_LIBRTE_KNI=n \
 			     CONFIG_RTE_KNI_KMOD=n \
-			     EXTRA_CFLAGS="-fPIC -w" -j $BUILD_THREADS \
+			     CONFIG_RTE_LIBRTE_PMD_PCAP=y \
+			     EXTRA_CFLAGS="-fPIC -w -ggdb" -j $BUILD_THREADS \
 			     > build_stdout.txt 2> build_stderr.txt
+	if [ $? = 0 ]; then
+		touch build_success
+		echo "	Built successfully"
+	else
+		rm build_success > /dev/null 2>&1
+		echo "	Build Failed"
+		DPDK_FAILED="$DPDK_FAILED
+Failed to build $dpdk_version"
+	fi
 	cd ..
 done
 
-rm -r "$BUILD_DIR" > /dev/null 2>&1
+rm -r "$BUILD_DIR" > /dev/null
 mkdir "$BUILD_DIR"
 if [ ! -d "$BUILD_DIR" ]; then
 	echo "ERROR: Could not create build directory"
@@ -101,6 +164,10 @@ cd "$DOWNLOAD_DIR"
 for dpdk_build in $(ls -d */)
 do
 	cd "$LIBTRACE_DIR"
+	# Skip any failed DPDK builds
+	if [ ! -f "$DOWNLOAD_DIR"/"$dpdk_build"/build_success ]; then
+		continue
+	fi
 	echo "Building libtrace with $dpdk_build - this may take some time"
 	export RTE_SDK="$DOWNLOAD_DIR"/"$dpdk_build"
 	export RTE_TARGET=x86_64-native-linuxapp-gcc
@@ -110,35 +177,76 @@ do
 	rm -r "$OUTPUT_PREFIX" > /dev/null 2> /dev/null
 	mkdir "$OUTPUT_PREFIX"
 	if [ ! -d "$OUTPUT_PREFIX" ]; then
-		echo "ERROR: Could not create libtrace build directory $dpdk_build"
+		echo "	ERROR: Could not create libtrace build directory $dpdk_build"
 		continue
 	fi
 	./bootstrap.sh > /dev/null 2> /dev/null
+	ERROR_MSG="Building libtrace against $dpdk_build"
 	do_test ./configure --with-dpdk --prefix="$OUTPUT_PREFIX" \
 		> "$OUTPUT_PREFIX"/conf_out.txt 2> "$OUTPUT_PREFIX"/conf_err.txt
+	if [ $? -ne 0 ]; then
+		LIBTRACE_FAILED="$LIBTRACE_FAILED
+./configure for libtrace failed against $dpdk_build
+	Are you missing dependencies or do you need to run bootstrap.sh?
+	check ${OUTPUT_PREFIX}conf_err.txt"
+		continue
+	fi
+	echo -n "	"
 	do_test grep "configure: Compiled with DPDK live capture support: Yes" \
 	             "$OUTPUT_PREFIX"/conf_out.txt  
-	do_test make -j $BUILD_THREADS \
+	if [ $? -ne 0 ]; then
+		LIBTRACE_FAILED="$LIBTRACE_FAILED
+./configure for libtrace did not detect dpdk $dpdk_build
+	check ${OUTPUT_PREFIX}conf_err.txt"
+		continue
+	fi
+	do_test make EXTRA_CFLAGS="-ggdb" -j $BUILD_THREADS \
 		> "$OUTPUT_PREFIX"/make_out.txt 2> "$OUTPUT_PREFIX"/make_err.txt
+	if [ $? -ne 0 ]; then
+		LIBTRACE_FAILED="$LIBTRACE_FAILED
+$dpdk_build Building libtrace failed (make)
+	check ${OUTPUT_PREFIX}make_err.txt"
+		continue
+	fi
 	do_test make install \
 		> "$OUTPUT_PREFIX"/install_out.txt 2> "$OUTPUT_PREFIX"/install_err.txt
-done
+	if [ $? -ne 0 ]; then
+		LIBTRACE_FAILED="$LIBTRACE_FAILED
+$dpdk_build Installing libtrace failed (make install)
+	check ${OUTPUT_PREFIX}install_err.txt"
+		continue
+	fi
 
-# Check we actually included dpdk
-cd "$BUILD_DIR"
-for dpdk_build in $(ls -d */)
-do
-	cd "$BUILD_DIR"/"$dpdk_build"/bin
+	if [ ! -f "$OUTPUT_PREFIX"/bin/tracepktdump ]; then
+		LIBTRACE_FAILED="$LIBTRACE_FAILED
+$dpdk_build Unexpected the build succeeded but tracepktdump is missing"
+		continue
+	fi
+
+	cd "$OUTPUT_PREFIX"/bin
+
+	echo -n "	"
 	./tracepktdump -H | grep "dpdk format module"
 	if [ $? -ne 0 ]; then
-		FAIL="$FAIL
-Failed to build $dpdk_build libtrace"
+		LIBTRACE_FAILED="$LIBTRACE_FAILED
+$dpdk_build Unexpected the build succeeded but tracepktdump does not accept the dpdk format"
+	else
+		SUCCESSFUL="$SUCCESSFUL
+$dpdk_build"
 	fi
 done
 
 echo
-echo "Tests passed: $OK"
-echo "Tests failed: $FAIL"
+echo "### Tests passed: $OK"
+echo
+echo "### Tests failed: $FAIL"
+echo
+echo "### Successfully built libtrace against the following versions of DPDK: $SUCCESSFUL"
+echo
+echo "### Failed to build or download these versions of DPDK: $DPDK_FAILED"
+echo
+echo "### Failed to build libtrace against the following versions of DPDK: $LIBTRACE_FAILED"
+echo
 if [ "$FAIL" != "" ]; then
 	echo "Some tests failed check the output logs"\
 	     "conf/make/install[_err/_out].txt" \

--- a/test/test-format-parallel-hasher.c
+++ b/test/test-format-parallel-hasher.c
@@ -287,14 +287,26 @@ uint64_t custom_hash(const libtrace_packet_t *packet UNUSED, void *data) {
         return 1;
 }
 
+static libtrace_t *trace = NULL;
+static void stop(int signal UNUSED)
+{
+        if (trace)
+                trace_pstop(trace);
+}
+
 int main(int argc, char *argv[]) {
 	int error = 0;
 	const char *tracename;
-	libtrace_t *trace;
         libtrace_callback_set_t *processing = NULL;
         libtrace_callback_set_t *reporter = NULL;
         uint32_t global = 0xabcdef;
         int hashercount = 0;
+        struct sigaction sigact;
+
+        sigact.sa_handler = stop;
+        sigemptyset(&sigact.sa_mask);
+        sigact.sa_flags = SA_RESTART;
+        sigaction(SIGINT, &sigact, NULL);
 
 	if (argc<2) {
 		fprintf(stderr,"usage: %s type\n",argv[0]);

--- a/test/test-format-parallel-reporter.c
+++ b/test/test-format-parallel-reporter.c
@@ -274,13 +274,25 @@ static void resume_processing(libtrace_t *trace UNUSED,
         storage->seen_resuming_message = true;
 }
 
+static libtrace_t *trace = NULL;
+static void stop(int signal UNUSED)
+{
+        if (trace)
+                trace_pstop(trace);
+}
+
 int main(int argc, char *argv[]) {
 	int error = 0;
 	const char *tracename;
-	libtrace_t *trace;
         libtrace_callback_set_t *processing = NULL;
         libtrace_callback_set_t *reporter = NULL;
         uint32_t global = 0xabcdef;
+        struct sigaction sigact;
+
+        sigact.sa_handler = stop;
+        sigemptyset(&sigact.sa_mask);
+        sigact.sa_flags = SA_RESTART;
+        sigaction(SIGINT, &sigact, NULL);
 
 	if (argc<2) {
 		fprintf(stderr,"usage: %s type\n",argv[0]);

--- a/test/test-format-parallel-singlethreaded-hasher.c
+++ b/test/test-format-parallel-singlethreaded-hasher.c
@@ -287,14 +287,26 @@ uint64_t custom_hash(const libtrace_packet_t *packet UNUSED, void *data) {
         return 1;
 }
 
+static libtrace_t *trace = NULL;
+static void stop(int signal UNUSED)
+{
+        if (trace)
+                trace_pstop(trace);
+}
+
 int main(int argc, char *argv[]) {
 	int error = 0;
 	const char *tracename;
-	libtrace_t *trace;
         libtrace_callback_set_t *processing = NULL;
         libtrace_callback_set_t *reporter = NULL;
         uint32_t global = 0xabcdef;
         int hashercount = 0;
+        struct sigaction sigact;
+
+        sigact.sa_handler = stop;
+        sigemptyset(&sigact.sa_mask);
+        sigact.sa_flags = SA_RESTART;
+        sigaction(SIGINT, &sigact, NULL);
 
 	if (argc<2) {
 		fprintf(stderr,"usage: %s type\n",argv[0]);

--- a/test/test-format-parallel-singlethreaded.c
+++ b/test/test-format-parallel-singlethreaded.c
@@ -271,13 +271,25 @@ static void resume_processing(libtrace_t *trace UNUSED,
         storage->seen_resuming_message = true;
 }
 
+static libtrace_t *trace = NULL;
+static void stop(int signal UNUSED)
+{
+        if (trace)
+                trace_pstop(trace);
+}
+
 int main(int argc, char *argv[]) {
 	int error = 0;
 	const char *tracename;
-	libtrace_t *trace;
         libtrace_callback_set_t *processing = NULL;
         libtrace_callback_set_t *reporter = NULL;
         uint32_t global = 0xabcdef;
+        struct sigaction sigact;
+
+        sigact.sa_handler = stop;
+        sigemptyset(&sigact.sa_mask);
+        sigact.sa_flags = SA_RESTART;
+        sigaction(SIGINT, &sigact, NULL);
 
 	if (argc<2) {
 		fprintf(stderr,"usage: %s type\n",argv[0]);

--- a/test/test-format-parallel.c
+++ b/test/test-format-parallel.c
@@ -275,13 +275,25 @@ static void resume_processing(libtrace_t *trace UNUSED,
         storage->seen_resuming_message = true;
 }
 
+static libtrace_t *trace = NULL;
+static void stop(int signal UNUSED)
+{
+        if (trace)
+                trace_pstop(trace);
+}
+
 int main(int argc, char *argv[]) {
 	int error = 0;
 	const char *tracename;
-	libtrace_t *trace;
         libtrace_callback_set_t *processing = NULL;
         libtrace_callback_set_t *reporter = NULL;
         uint32_t global = 0xabcdef;
+        struct sigaction sigact;
+
+        sigact.sa_handler = stop;
+        sigemptyset(&sigact.sa_mask);
+        sigact.sa_flags = SA_RESTART;
+        sigaction(SIGINT, &sigact, NULL);
 
 	if (argc<2) {
 		fprintf(stderr,"usage: %s type\n",argv[0]);

--- a/test/test-live-snaplen.c
+++ b/test/test-live-snaplen.c
@@ -67,6 +67,8 @@ static const char *lookup_uri_write(const char *type)
 		return "pcapint:veth0";
 	if (!strncmp(type, "dpdk:", sizeof("dpdk:")))
 		return type;
+	if (!strncmp(type, "dpdkvdev", sizeof("dpdkvdev")))
+		return "dpdkvdev:net_pcap0,iface=veth0";
 	return "unknown";
 }
 
@@ -80,6 +82,8 @@ static const char *lookup_uri_read(const char *type)
 		return "pcapint:veth1";
 	if (!strncmp(type, "dpdk:", sizeof("dpdk:")))
 		return type;
+	if (!strncmp(type, "dpdkvdev", sizeof("dpdkvdev")))
+		return "dpdkvdev:net_pcap0,iface=veth1";
 	return "unknown";
 }
 

--- a/test/test-live-snaplen.c
+++ b/test/test-live-snaplen.c
@@ -57,36 +57,6 @@
 static const char *uri_read;
 static libtrace_t *trace_read;
 
-static const char *lookup_uri_write(const char *type)
-{
-	if (!strcmp(type, "int"))
-		return "int:veth0";
-	if (!strcmp(type, "ring"))
-		return "ring:veth0";
-	if (!strcmp(type, "pcapint"))
-		return "pcapint:veth0";
-	if (!strncmp(type, "dpdk:", sizeof("dpdk:")))
-		return type;
-	if (!strncmp(type, "dpdkvdev", sizeof("dpdkvdev")))
-		return "dpdkvdev:net_pcap0,iface=veth0";
-	return "unknown";
-}
-
-static const char *lookup_uri_read(const char *type)
-{
-	if (!strcmp(type, "int"))
-		return "int:veth1";
-	if (!strcmp(type, "ring"))
-		return "ring:veth1";
-	if (!strcmp(type, "pcapint"))
-		return "pcapint:veth1";
-	if (!strncmp(type, "dpdk:", sizeof("dpdk:")))
-		return type;
-	if (!strncmp(type, "dpdkvdev", sizeof("dpdkvdev")))
-		return "dpdkvdev:net_pcap0,iface=veth1";
-	return "unknown";
-}
-
 
 /**
  * Source packet we modify this every write see build_packet
@@ -183,9 +153,9 @@ int main(int argc, char *argv[])
 	// Timeout after 5 seconds
 	alarm(5);
 
-	trace_write = trace_create_output(lookup_uri_write(argv[1]));
+	trace_write = trace_create_output(argv[1]);
 	iferr_out(trace_write);
-	uri_read = lookup_uri_read(argv[2]);
+	uri_read = argv[2];
 	trace_read = trace_create(uri_read);
 	iferr(trace_read);
 

--- a/test/test-live.c
+++ b/test/test-live.c
@@ -65,46 +65,11 @@
 	) \
 }
 
-static const char *uri_read;
+static const char *uri_read = "";
 static sig_atomic_t i = 0;
 static sig_atomic_t reading = 0;
-static libtrace_t *trace_read;
+static libtrace_t *trace_read = NULL;
 static int test_size = 100;
-
-static const char *lookup_uri_write(const char *type)
-{
-	if (!strcmp(type, "int"))
-		return "int:veth0";
-	if (!strcmp(type, "ring"))
-		return "ring:veth0";
-	if (!strcmp(type, "pcapint"))
-		return "pcapint:veth0";
-	if (!strncmp(type, "dpdk:", sizeof("dpdk:")))
-		return type;
-	if (!strncmp(type, "dpdkvdev", sizeof("dpdkvdev")))
-		return "dpdkvdev:net_pcap0,iface=veth0";
-	return "unknown";
-}
-
-static const char *lookup_uri_read(const char *type)
-{
-	if (!strcmp(type, "int"))
-		return "int:veth1";
-	if (!strcmp(type, "ring"))
-		return "ring:veth1";
-	if (!strcmp(type, "pcapint")) {
-		// The newer Linux memmap (ring:) implementation of PCAP only makes
-		// space for about 30 maybe 31 packet buffers. If we exceeded this we'll
-		// drop packets.
-		test_size = 30; 
-		return "pcapint:veth1";
-	}
-	if (!strncmp(type, "dpdk:", sizeof("dpdk:")))
-		return type;
-	if (!strncmp(type, "dpdkvdev", sizeof("dpdkvdev")))
-		return "dpdkvdev:net_pcap0,iface=veth1";
-	return "unknown";
-}
 
 
 /**
@@ -323,8 +288,8 @@ int main(int argc, char *argv[])
 	int psize;
 	int err = 0;
 
-	if (argc < 3) {
-		fprintf(stderr, "usage: %s type(write) type(read)\n", argv[0]);
+	if (argc < 2) {
+		fprintf(stderr, "usage: %s type(write) [type(read)]\n", argv[0]);
 		return 1;
 	}
 
@@ -332,16 +297,27 @@ int main(int argc, char *argv[])
 	// Timeout after 5 seconds
 	alarm(5);
 
-	trace_write = trace_create_output(lookup_uri_write(argv[1]));
+	trace_write = trace_create_output(argv[1]);
 	iferr_out(trace_write);
-	uri_read = lookup_uri_read(argv[2]);
-	trace_read = trace_create(uri_read);
-	iferr(trace_read);
+	if (argc > 2) {
+		uri_read = argv[2];
+		trace_read = trace_create(uri_read);
+		iferr(trace_read);
+	}
+
+	if (strncmp(uri_read, "pcapint", 7) == 0) {
+		/* The newer Linux memmap (ring:) implementation of PCAP only makes
+		 * space for about 30 maybe 31 packet buffers. If we exceed this we'll
+		 * drop packets. */
+		test_size = 30;
+	}
 
 	trace_start_output(trace_write);
 	iferr_out(trace_write);
-	trace_start(trace_read);
-	iferr(trace_read);
+	if (argc > 2) {
+		trace_start(trace_read);
+		iferr(trace_read);
+	}
 
 	packet = trace_create_packet();
 
@@ -355,6 +331,11 @@ int main(int argc, char *argv[])
 	}
 	trace_destroy_packet(packet);
 	trace_destroy_output(trace_write);
+
+	if (argc <= 2) {
+		printf("Sent %d packets\n", test_size);
+		return 0;
+	}
 
 	// Now read back in, we assume that buffers internally can buffer
 	// the packets without losing them

--- a/test/test-live.c
+++ b/test/test-live.c
@@ -81,6 +81,8 @@ static const char *lookup_uri_write(const char *type)
 		return "pcapint:veth0";
 	if (!strncmp(type, "dpdk:", sizeof("dpdk:")))
 		return type;
+	if (!strncmp(type, "dpdkvdev", sizeof("dpdkvdev")))
+		return "dpdkvdev:net_pcap0,iface=veth0";
 	return "unknown";
 }
 
@@ -99,6 +101,8 @@ static const char *lookup_uri_read(const char *type)
 	}
 	if (!strncmp(type, "dpdk:", sizeof("dpdk:")))
 		return type;
+	if (!strncmp(type, "dpdkvdev", sizeof("dpdkvdev")))
+		return "dpdkvdev:net_pcap0,iface=veth1";
 	return "unknown";
 }
 

--- a/tools/tracemcast/tracemcast.c
+++ b/tools/tracemcast/tracemcast.c
@@ -318,8 +318,8 @@ static uint16_t construct_erf_header(read_thread_data_t *rdata,
     return framing;
 }
 
-static void tick_reader_thread(libtrace_t *trace,
-        libtrace_thread_t *t, void *global UNUSED, void *tls,
+static void tick_reader_thread(libtrace_t *trace UNUSED,
+        libtrace_thread_t *t UNUSED, void *global UNUSED, void *tls,
         uint64_t order) {
 
     read_thread_data_t *rdata = (read_thread_data_t *)tls;

--- a/tools/tracesplit/tracesplit.c
+++ b/tools/tracesplit/tracesplit.c
@@ -514,6 +514,25 @@ int main(int argc, char *argv[])
 			trace_perror(input,"Reading packets");
 			trace_destroy(input);
 			break;
+		} else if (verbose) {
+			libtrace_stat_t *stat;
+
+			stat = trace_create_statistics();
+			trace_get_statistics(input, stat);
+
+			if (stat->received_valid)
+				fprintf(stderr,"%" PRIu64 " packets on input\n",
+						stat->received);
+			if (stat->filtered_valid)
+				fprintf(stderr,"%" PRIu64 " packets filtered\n",
+						stat->filtered);
+			if (stat->dropped_valid)
+				fprintf(stderr,"%" PRIu64 " packets dropped\n",
+						stat->dropped);
+			if (stat->accepted_valid)
+				fprintf(stderr,"%" PRIu64 " packets accepted\n",
+						stat->accepted);
+			free(stat);
 		}
 
 		trace_destroy(input);
@@ -523,26 +542,6 @@ int main(int argc, char *argv[])
 		
 	}
 
-	if (verbose) {
-                libtrace_stat_t *stat;
-                
-                stat = trace_create_statistics();
-                trace_get_statistics(input, stat);
-
-                if (stat->received_valid)
-			fprintf(stderr,"%" PRIu64 " packets on input\n",
-                                        stat->received);
-		if (stat->filtered_valid)
-			fprintf(stderr,"%" PRIu64 " packets filtered\n",
-                                        stat->filtered);
-		if (stat->dropped_valid)
-			fprintf(stderr,"%" PRIu64 " packets dropped\n",
-                                        stat->dropped);
-		if (stat->accepted_valid)
-			fprintf(stderr,"%" PRIu64 " packets accepted\n",
-                                        stat->accepted);
-	        free(stat);
-        }
 	
 	if (output)
 		trace_destroy_output(output);


### PR DESCRIPTION
New DPDK features:
 * Added vdev support (very useful for debugging and testing without hardware)
 * Support for DPDK 19.11
    - DPDK rename ETHER_CRC_LEN -> RTE_ETHER_CRC_LEN
    - Update our handling for threads to avoid updating internal lcore structures as
      the global config structure was removed in DPDK 19.11.
    - Fix for ./configure detection and linking against the system's version of DPDK

DPDK fixes:
 * Tidies some existing DPDK version compatibility checks
 * Fix setting an unknown packet direction against a DPDK packet
 * Improved debug messages
 * Fix DPDK's snaplen handling
 * Fix write (tx) path to ensure link is fully up before sending packets
 * Fix possible array overflow in memory allocation if more than 4 numa nodes
   and tidy allocation
 * Partial fix for files left behind by after running libtrace with DPDK, which fill up:
  - /var/run/dpdk/libtrace*
  - /dev/hugepages/libtrace*
  - /var/run/.libtrace*
  If the crash occurs during initialisation these might not be tidied up correctly.

I've tested with DPDK versions 16.11, 17.11, 18.11, 19.11, 20.02 on 10g-dev2
Debian 8 (Jessie) with the Intel x520 82599 card against the DAG. Other than a
DPDK link status bug since 19.11 where the 82599 card always reports link
down, it works correctly.

I've tested with the system DPDK  (19.11) on Ubuntu 20.04 (Focal Fossa) between two Intel X710 NICs. Libtrace+DPDK works correctly, however, I uncovered a DPDK (or potentially a hardware bug). With more than 8 RX queues (and threads) I saw between 100-200 extra packets counted as received (total of accepted + dropped) by libtrace, regardless of the test duration or number of threads beyond that point. So it makes me think it is uninitialised data coming from somewhere. I saw the same behaviour with the DPDK tool test-pmd but this time when using more than 7 threads, so I'm happy it is not a Libtrace bug. It could also be a legitimate count if it was counting pause frames? Though pause frames shouldn't be being generated.

Tests suite updates:
 * Many updates to the robustness of do-test-build-dpdk.sh
 * Update do-live-tests.sh to test DPDK using veths
 * Updated do-live-tests.sh to test the parallel API
 * Added do-test-build-live.sh as helper to run all DPDK test builds against do-live-tests.sh

Other fixes:
 * Fix compiler warnings in tracemcast (unused vars)
 * Fix bug where a dedicated hasher thread incorrectly called pregister_thread despite
   using the old single threaded API
 * Fix seg fault in sanity check in linuxcommon_pregister_thread
 * Fix tracesplit reading statistics from a destroyed trace