### PR TITLE
#116 Multi-threaded programs halt after a while if some threads see no packets

### DIFF
--- a/lib/format_linux_xdp.c
+++ b/lib/format_linux_xdp.c
@@ -790,6 +790,7 @@ static int linux_xdp_start_stream(struct xsk_config *cfg,
 
 static int linux_xdp_read_stream(libtrace_t *libtrace,
                                  libtrace_packet_t *packet[],
+                                 libtrace_message_queue_t *msg,
                                  struct xsk_per_stream *stream,
                                  size_t nb_packets) {
 
@@ -836,6 +837,10 @@ static int linux_xdp_read_stream(libtrace_t *libtrace,
         if (rcvd < 1) {
             /* poll will return 0 on timeout or a positive on a event */
             ret = poll(&fds, 1, 500);
+
+            if (msg && libtrace_message_queue_count(msg) > 0) {
+                return READ_MESSAGE;
+            }
 
             /* poll encountered a error */
             if (ret < 0) {
@@ -892,7 +897,11 @@ static int linux_xdp_read_packet(libtrace_t *libtrace, libtrace_packet_t *packet
 
     stream = (struct xsk_per_stream *)node->data;
 
-    return linux_xdp_read_stream(libtrace, &packet, stream, 1);
+    return linux_xdp_read_stream(libtrace,
+                                 &packet,
+                                 NULL,
+                                 stream,
+                                 1);
 
 }
 
@@ -904,7 +913,11 @@ static int linux_xdp_pread_packets(libtrace_t *libtrace,
     int nb_rx;
     struct xsk_per_stream *stream = thread->format_data;
 
-    nb_rx = linux_xdp_read_stream(libtrace, packets, stream, nb_packets);
+    nb_rx = linux_xdp_read_stream(libtrace,
+                                  packets,
+                                  &thread->messages,
+                                  stream,
+                                  nb_packets);
 
     return nb_rx;
 }

--- a/lib/format_ndag.c
+++ b/lib/format_ndag.c
@@ -1262,7 +1262,7 @@ static int receive_from_sockets(recvstream_t *rt) {
 
 
 static int receive_encap_records_block(libtrace_t *libtrace, recvstream_t *rt,
-                libtrace_packet_t *packet) {
+                libtrace_packet_t *packet, libtrace_message_queue_t *msg) {
 
         int iserr = 0;
 
@@ -1298,6 +1298,11 @@ static int receive_encap_records_block(libtrace_t *libtrace, recvstream_t *rt,
                         /* At least one of our input sockets has available
                          * data, let's go ahead and use what we have. */
                         break;
+                }
+
+                /* Check for any messages in the message queue. Process them if so */
+                if (msg && libtrace_message_queue_count(msg) > 0) {
+                    return READ_MESSAGE;
                 }
 
                 /* None of our sources have anything available, we can take
@@ -1379,7 +1384,7 @@ static int ndag_read_packet(libtrace_t *libtrace, libtrace_packet_t *packet) {
         int rem, ret;
         streamsock_t *nextavail = NULL;
         rem = receive_encap_records_block(libtrace, &(FORMAT_DATA->receivers[0]),
-                        packet);
+                        packet, NULL);
 
         if (rem <= 0) {
                 return rem;
@@ -1415,7 +1420,7 @@ static int ndag_pread_packets(libtrace_t *libtrace, libtrace_thread_t *t,
                 /* Only check for messages once per batch */
                 if (read_packets == 0) {
                         rem = receive_encap_records_block(libtrace, rt,
-                                packets[read_packets]);
+                                packets[read_packets], &t->messages);
                         if (rem < 0) {
                                 return rem;
                         }


### PR DESCRIPTION
Check for messages in the threads message queue and process them if available instead of continuously polling for packets. This prevents a backlog of tick packets filling up the message queue causing it to block and never recover and should resolve issue #116