### PR TITLE
116 - Multi-threaded programs halt after a while if some threads see no packets

### DIFF
--- a/examples/parallel/timedemo.c
+++ b/examples/parallel/timedemo.c
@@ -144,6 +144,12 @@ static void process_tick(libtrace_t *trace, libtrace_thread_t *t,
 
         struct localdata *local = (struct localdata *)tls;
 
+        /* If a packet has received a tick event before a packet is seen
+         * nextreport needs to be set */
+        if (local->nextreport == 0) {
+            local->nextreport = tick + SECONDS_TO_ERF(10);
+        }
+
         while (local->nextreport && tick > local->nextreport) {
                 libtrace_generic_t c;
                 c.uint64 = local->count;

--- a/examples/parallel/timedemo.c
+++ b/examples/parallel/timedemo.c
@@ -144,7 +144,7 @@ static void process_tick(libtrace_t *trace, libtrace_thread_t *t,
 
         struct localdata *local = (struct localdata *)tls;
 
-        /* If a packet has received a tick event before a packet is seen
+        /* If a thread has received a tick event before a packet is seen
          * nextreport needs to be set */
         if (local->nextreport == 0) {
             local->nextreport = tick + SECONDS_TO_ERF(10);

--- a/lib/format_dag25.c
+++ b/lib/format_dag25.c
@@ -1352,13 +1352,15 @@ static int dag_read_packet_stream(libtrace_t *libtrace,
 		if (numbytes < 0)
 			return numbytes;
 		if (numbytes < dag_record_size) {
-			/* Check the message queue if we have one to check */
-			if (t != NULL &&
-			    libtrace_message_queue_count(&t->messages) > 0)
-				return -2;
+			/* if we have access to the message queue check for a message
+                         * otherwise we need to return and let libtrace check for a message
+                         */
+			if ((t && libtrace_message_queue_count(&t->messages) > 0) || !t)
+				return READ_MESSAGE;
 
 			if ((numbytes=is_halted(libtrace)) != -1)
 				return numbytes;
+
 			/* Block until we see a packet */
 			continue;
 		}

--- a/lib/format_dpdk.c
+++ b/lib/format_dpdk.c
@@ -2087,8 +2087,10 @@ int dpdk_read_packet_stream (libtrace_t *libtrace,
 			//fprintf(stderr, "Doing P READ PACKET port=%d q=%d\n", (int) FORMAT(libtrace)->port, (int) get_thread_table_num(libtrace));
 			return nb_rx;
 		}
-		/* Check the message queue this could be less than 0 */
-		if (mesg && libtrace_message_queue_count(mesg) > 0)
+		/* Check the message queue this could be less than 0.
+                 * If the message queue is not available return and let libtrace
+                 * check for new messages. */
+		if ((mesg && libtrace_message_queue_count(mesg) > 0) || !mesg)
 			return READ_MESSAGE;
 		if ((nb_rx=is_halted(libtrace)) != (size_t) -1)
 			return nb_rx;

--- a/lib/format_linux_int.c
+++ b/lib/format_linux_int.c
@@ -235,6 +235,11 @@ inline static int linuxnative_read_stream(libtrace_t *libtrace,
 			} else {
 				if ((ret=is_halted(libtrace)) != -1)
 					return ret;
+                                /* If we dont have access to the queue we have to return
+                                 * and let libtrace check */
+                                if (!queue) {
+                                    return READ_MESSAGE;
+                                }
 			}
 		}
 		while (ret <= 0);

--- a/lib/format_linux_ring.c
+++ b/lib/format_linux_ring.c
@@ -597,7 +597,13 @@ inline static int linuxring_read_stream(libtrace_t *libtrace,
 				return -1;
 			}
 		} else {
-			/* Poll timed out - check if we should exit on next loop */
+			/* Poll timed out. If we do not have access to the message queue
+                         * return and let libtrace check it, otherwise loop.
+                         */
+                        if (!queue) {
+                            return READ_MESSAGE;
+                        }
+
 			continue;
 		}
 	}

--- a/lib/format_linux_xdp.c
+++ b/lib/format_linux_xdp.c
@@ -838,7 +838,10 @@ static int linux_xdp_read_stream(libtrace_t *libtrace,
             /* poll will return 0 on timeout or a positive on a event */
             ret = poll(&fds, 1, 500);
 
-            if (msg && libtrace_message_queue_count(msg) > 0) {
+            /* if we have access to the message queue check for a message
+             * otherwise we need to return and let libtrace check for a message
+             */
+            if ((msg && libtrace_message_queue_count(msg) > 0) || !msg) {
                 return READ_MESSAGE;
             }
 

--- a/lib/format_linux_xdp.c
+++ b/lib/format_linux_xdp.c
@@ -790,6 +790,7 @@ static int linux_xdp_start_stream(struct xsk_config *cfg,
 
 static int linux_xdp_read_stream(libtrace_t *libtrace,
                                  libtrace_packet_t *packet[],
+                                 libtrace_message_queue_t *msg,
                                  struct xsk_per_stream *stream,
                                  size_t nb_packets) {
 
@@ -836,6 +837,10 @@ static int linux_xdp_read_stream(libtrace_t *libtrace,
         if (rcvd < 1) {
             /* poll will return 0 on timeout or a positive on a event */
             ret = poll(&fds, 1, 500);
+
+            if (msg && libtrace_message_queue_count(msg) > 0) {
+                return READ_MESSAGE;
+            }
 
             /* poll encountered a error */
             if (ret < 0) {
@@ -892,7 +897,11 @@ static int linux_xdp_read_packet(libtrace_t *libtrace, libtrace_packet_t *packet
 
     stream = (struct xsk_per_stream *)node->data;
 
-    return linux_xdp_read_stream(libtrace, &packet, stream, 1);
+    return linux_xdp_read_stream(libtrace,
+                                 &packet,
+                                 NULL,
+                                 stream,
+                                 1);
 
 }
 
@@ -904,7 +913,11 @@ static int linux_xdp_pread_packets(libtrace_t *libtrace,
     int nb_rx;
     struct xsk_per_stream *stream = thread->format_data;
 
-    nb_rx = linux_xdp_read_stream(libtrace, packets, stream, nb_packets);
+    nb_rx = linux_xdp_read_stream(libtrace,
+                                  packets,
+                                  &thread->messages,
+                                  stream,
+                                  nb_packets);
 
     return nb_rx;
 }

--- a/lib/format_ndag.c
+++ b/lib/format_ndag.c
@@ -1300,8 +1300,10 @@ static int receive_encap_records_block(libtrace_t *libtrace, recvstream_t *rt,
                         break;
                 }
 
-                /* Check for any messages in the message queue. Process them if so */
-                if (msg && libtrace_message_queue_count(msg) > 0) {
+                /* if we have access to the message queue check for a message
+                 * otherwise we need to return and let libtrace check for a message
+                 */
+                if ((msg && libtrace_message_queue_count(msg) > 0) || !msg) {
                     return READ_MESSAGE;
                 }
 

--- a/lib/format_ndag.c
+++ b/lib/format_ndag.c
@@ -1262,7 +1262,7 @@ static int receive_from_sockets(recvstream_t *rt) {
 
 
 static int receive_encap_records_block(libtrace_t *libtrace, recvstream_t *rt,
-                libtrace_packet_t *packet) {
+                libtrace_packet_t *packet, libtrace_message_queue_t *msg) {
 
         int iserr = 0;
 
@@ -1298,6 +1298,11 @@ static int receive_encap_records_block(libtrace_t *libtrace, recvstream_t *rt,
                         /* At least one of our input sockets has available
                          * data, let's go ahead and use what we have. */
                         break;
+                }
+
+                /* Check for any messages in the message queue. Process them if so */
+                if (msg && libtrace_message_queue_count(msg) > 0) {
+                    return READ_MESSAGE;
                 }
 
                 /* None of our sources have anything available, we can take
@@ -1379,7 +1384,7 @@ static int ndag_read_packet(libtrace_t *libtrace, libtrace_packet_t *packet) {
         int rem, ret;
         streamsock_t *nextavail = NULL;
         rem = receive_encap_records_block(libtrace, &(FORMAT_DATA->receivers[0]),
-                        packet);
+                        packet, NULL);
 
         if (rem <= 0) {
                 return rem;
@@ -1415,7 +1420,7 @@ static int ndag_pread_packets(libtrace_t *libtrace, libtrace_thread_t *t,
                 /* Only check for messages once per batch */
                 if (read_packets == 0) {
                         rem = receive_encap_records_block(libtrace, rt,
-                                packets[read_packets]);
+                                packets[read_packets], &t->messages);
                         if (rem < 0) {
                                 return rem;
                         }

--- a/lib/format_pcap.c
+++ b/lib/format_pcap.c
@@ -502,7 +502,10 @@ static int pcap_read_packet(libtrace_t *libtrace, libtrace_packet_t *packet) {
 			case 0: 
 				if ((ret=is_halted(libtrace)) != -1)
 					return ret;
-                                continue; /* timeout expired */
+                                /* timeout, return and let libtrace check message
+                                 * queue.
+                                 */
+                                return READ_MESSAGE;
 			case -1: 
 				trace_set_err(libtrace,TRACE_ERR_BAD_PACKET,
 						"%s",pcap_geterr(INPUT.pcap));

--- a/lib/format_tzsplive.c
+++ b/lib/format_tzsplive.c
@@ -441,7 +441,6 @@ static int tzsplive_read_packet(libtrace_t *libtrace, libtrace_packet_t *packet)
 	}
 	flags |= TRACE_PREP_OWN_BUFFER;
 
-readagain:
 	/* Make sure we shouldnt be halting */
 	if ((ret = is_halted(libtrace)) != -1) {
 		return ret;
@@ -453,9 +452,12 @@ readagain:
 	if (ret == -1) {
 		/* Nothing available to read */
 		if (errno == EAGAIN || errno == EWOULDBLOCK) {
-			/* sleep for a short period and check again */
+			/* sleep for a short period */
 			usleep(100);
-			goto readagain;
+                        /* return and let libtrace check for new message in the
+                         * message queue.
+                         */
+                        return READ_MESSAGE;
 		}
 		/* Socket error */
 		trace_set_err(libtrace, TRACE_ERR_BAD_IO, "Error receiving on socket "

--- a/lib/trace.c
+++ b/lib/trace.c
@@ -1043,8 +1043,10 @@ DLLEXPORT int trace_read_packet(libtrace_t *libtrace, libtrace_packet_t *packet)
 			packet->trace = libtrace;
                         packet->which_trace_start = libtrace->startcount;
 			ret=libtrace->format->read_packet(libtrace,packet);
-			if (ret==(size_t)READ_MESSAGE ||
-                            ret==(size_t)-1 || ret==0) {
+			if (ret==(size_t)READ_MESSAGE) {
+				continue;
+			}
+                        if (ret==(size_t)-1 || ret==0) {
                                 packet->trace = NULL;
 				return ret;
 			}

--- a/lib/trace_parallel.c
+++ b/lib/trace_parallel.c
@@ -716,6 +716,7 @@ static void* perpkt_threads_entry(void *data) {
 			}
                         send_message(trace, t, message.code, message.data, 
                                         message.sender);
+
 			/* Continue and the empty messages out before packets */
 			continue;
 		}
@@ -1014,6 +1015,16 @@ inline static int trace_pread_packet_hasher_thread(libtrace_t *libtrace,
                                                    libtrace_packet_t *packets[],
                                                    size_t nb_packets) {
 	size_t i;
+
+        while (libtrace_ringbuffer_is_empty(&t->rbuffer)) {
+
+                /* does libtrace have any messages in the queue */
+                if (libtrace_message_queue_count(&t->messages) > 0) {
+                    return READ_MESSAGE;
+                }
+
+                usleep(100);
+        }
 
 	/* We store the last error message here */
 	if (t->format_data) {


### PR DESCRIPTION
The timedemo example application would only initialize the nextreport variable if a packet is seen preventing results from being published by threads that have not seen any packets. This caused the ordered combiner to queue up messages preventing any results being printed.

When using a custom hasher function the packet threads would block waiting for a new packet. This prevented ticks from being triggered when no packets are seen. Instead we now check if the ring buffer contains a new packet, if it does we enter the blocking call which will not block because a packet is available, if no packets are available we check the threads message queue for a message and repeat.

If a format module does not have a packet it should check the threads message queue for a message, if one is available returning READ_MESSAGE will allow libtrace to process it. If the format module does not have access to the threads messages it should not block till a packet arrives and instead poll for a short period and if no packet are received return READ_MESSAGE.



