### PR TITLE
Traceends - Fix incorrect byte counters for IPv4 sources

### DIFF
--- a/tools/traceends/traceends.cc
+++ b/tools/traceends/traceends.cc
@@ -448,7 +448,7 @@ static void update_ipv4(global_t *glob,
 
                 c->src_pkts ++;
                 c->src_pbytes += plen;
-                c->src_bytes += ip->ip_len;
+                c->src_bytes += ip_len;
                 if (ts != 0)
                         c->last_active = ts;
         }


### PR DESCRIPTION
Fixes - traceends: incorrect calculation of bytes originated from an endpoint #136