### PR TITLE
Fix bug where libpacketdump would truncate Linux SLL packets

### DIFF
--- a/lib/libtrace.h.in
+++ b/lib/libtrace.h.in
@@ -1281,7 +1281,7 @@ typedef struct libtrace_sll_header_t {
         uint16_t halen;                 /**< Link-layer address length */
         unsigned char addr[8];          /**< Link-layer address */
         uint16_t protocol;              /**< Protocol */
-} libtrace_sll_header_t;
+} PACKED libtrace_sll_header_t;
 
 
 /* SLL packet types */

--- a/libpacketdump/link_6.c
+++ b/libpacketdump/link_6.c
@@ -84,7 +84,7 @@ DLLEXPORT void decode(int link_type ,const char *pkt,unsigned len)
 	/* Decide how to continue processing... */
 	
 	/* Do we recognise the hardware address type? */
-	ret=trace_get_payload_from_meta(pkt, &linktype, &len);
+        ret=trace_get_payload_from_meta(pkt, &linktype, &len);
 	
 	if (ntohs(sll->hatype) == LIBTRACE_ARPHRD_ETHER || 
 				ntohs(sll->hatype) == LIBTRACE_ARPHRD_LOOPBACK) { 
@@ -93,9 +93,9 @@ DLLEXPORT void decode(int link_type ,const char *pkt,unsigned len)
 			decode_next(ret, len, "link", 
 				arphrd_type_to_libtrace(ntohs(sll->hatype)));
 		}
-		else
-			decode_next(pkt + sizeof(*sll), len - sizeof(*sll), 
-					"eth", ntohs(sll->protocol));
+		else if (ret) {
+			decode_next(ret, len, "eth", ntohs(sll->protocol));
+                }
 	}
 	else {
 		decode_next(ret, len, "link", 


### PR DESCRIPTION
The length of the SLL header was being deducted twice from
the "remaining" packet, so libpacketdump would not display the
last 16 bytes of any given SLL packet.