### PR TITLE
XDP fix to correctly free umem buffer, Fix: #144

### DIFF
--- a/lib/libtrace.h.in
+++ b/lib/libtrace.h.in
@@ -694,7 +694,7 @@ typedef struct libtrace_packet_t {
 	uint64_t hash;                  /**< A hash of the packet as supplied by the user */
 	int error;                      /**< The error status of pread_packet */
         uint64_t internalid;            /** Internal identifier for the pkt */
-        void *srcbucket;
+        void *srcbucket;                /** Source bucket in trace_rt or stream in XDP */
 
         pthread_mutex_t ref_lock;       /**< Lock for reference counter */
         int refcount;                   /**< Reference counter */


### PR DESCRIPTION
Patch to release the packet buffer that came from the RX queue
back to the fill queue. Previously we did not update the fill
queue. So the code was working on the assumption that packets
were always returned in the same order both by the kernel and
libtrace application.

Remaining:
Currently, the fin_packet code is not thread-safe, so the thread
which received the packet needs to be the one that also frees it.
While libtrace doesn't guarantee this will work for other formats,
if we can do it without a large performance hit we should try.

Check that this hasn't hurt performance too much. Maybe
releasing back to the fill queue should be done in batches?