### PR TITLE
Add tracepoint support

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -227,6 +227,20 @@ fi
 AC_CHECK_LIB(yaml, yaml_parser_initialize, yamlfound=1, yamlfound=0)
 AC_CHECK_LIB(tasn1, asn1_array2tree, asn1found=1, asn1found=0)
 
+systemtap=false
+# check if the system has systemtap header
+AC_ARG_ENABLE(dtrace, AS_HELP_STRING(--enable-dtrace, Include USDT tracepoints),
+[
+	AC_CHECK_HEADER(sys/sdt.h, [systemtap=true], [systemtap=false])
+	if test "$systemtap" = false; then
+		AC_MSG_ERROR([systemtap-sdt-dev is required to include USDT tracepoints])
+	fi
+	AC_DEFINE(ENABLE_DTRACE, 1, [Set to 1 if libtrace is to be compiled with USDT tracepoints])
+],
+[
+	AC_DEFINE(ENABLE_DTRACE, 0, [Set to 1 if libtrace is to be compiled with USDT tracepoints])
+])
+
 
 # check for xdp requirements.
 libtrace_xdp=false
@@ -828,6 +842,8 @@ AM_CONDITIONAL([HAVE_DPDK_PKGCONFIG], [test "x$dpdk_found" = "xpkgconfig"])
 AM_CONDITIONAL([HAVE_LIBBPF], [test "x$libtrace_xdp" = "xtrue"])
 AM_CONDITIONAL([BUILD_EBPF], [test "x$build_ebpf" = "xtrue"])
 
+AM_CONDITIONAL([ENABLE_DTRACE], [test "x$systemtap" = "xtrue"])
+
 # Check for miscellaneous programs
 AC_CHECK_PROG([libtrace_doxygen], [doxygen], [true], [false])
 
@@ -887,6 +903,12 @@ if test x"$libtrace_dag" = xtrue; then
 	fi	
 else
 	AC_MSG_NOTICE([Compiled with DAG live capture support: No])
+fi
+
+if test x"$systemtap" = xtrue; then
+	AC_MSG_NOTICE([Compiled with USDT tracepoints: Yes])
+else
+	AC_MSG_NOTICE([Compiled with USDT tracepoints: No])
 fi
 
 # Are we building with XDP support

--- a/lib/format_dpdk.c
+++ b/lib/format_dpdk.c
@@ -2138,6 +2138,9 @@ int dpdk_read_packet_stream (libtrace_t *libtrace,
 		nb_rx = rte_eth_rx_burst(FORMAT(libtrace)->port,
 		                         stream->queue_id, pkts_burst, nb_packets);
 		if (nb_rx > 0) {
+#if ENABLE_DTRACE
+                        DTRACE_PROBE1(libtrace, dpdk_received_packets, nb_rx);
+#endif
 			/* Got some packets - otherwise we keep spining */
 			dpdk_ready_pkts(libtrace, stream, pkts_burst, nb_rx);
 			//fprintf(stderr, "Doing P READ PACKET port=%d q=%d\n", (int) FORMAT(libtrace)->port, (int) get_thread_table_num(libtrace));
@@ -2146,12 +2149,21 @@ int dpdk_read_packet_stream (libtrace_t *libtrace,
 		/* Check the message queue this could be less than 0.
                  * If the message queue is not available return and let libtrace
                  * check for new messages. */
-		if ((mesg && libtrace_message_queue_count(mesg) > 0) || !mesg)
+		if ((mesg && libtrace_message_queue_count(mesg) > 0) || !mesg) {
+#if ENABLE_DTRACE
+                        DTRACE_PROBE(libtrace, dpdk_read_message);
+#endif
 			return READ_MESSAGE;
+                }
+
 		if ((nb_rx=is_halted(libtrace)) != (size_t) -1)
 			return nb_rx;
+
 		/* Wait a while, polling on memory degrades performance
 		 * This relieves the pressure on memory allowing the NIC to DMA */
+#if ENABLE_DTRACE
+                DTRACE_PROBE(libtrace, dpdk_delay);
+#endif
 		rte_delay_us(10);
 	}
 

--- a/lib/format_linux_xdp.c
+++ b/lib/format_linux_xdp.c
@@ -941,6 +941,9 @@ static int linux_xdp_read_stream(libtrace_t *libtrace,
              * otherwise we need to return and let libtrace check for a message
              */
             if ((msg && libtrace_message_queue_count(msg) > 0) || !msg) {
+#if ENABLE_DTRACE
+                DTRACE_PROBE(libtrace, xdp_read_message);
+#endif
                 return READ_MESSAGE;
             }
 
@@ -951,6 +954,10 @@ static int linux_xdp_read_stream(libtrace_t *libtrace,
             }
         }
     }
+
+#if ENABLE_DTRACE
+    DTRACE_PROBE1(libtrace, xdp_received_packets, rcvd);
+#endif
 
     sys_time = linux_xdp_get_time();
 

--- a/lib/libtrace.h.in
+++ b/lib/libtrace.h.in
@@ -64,6 +64,10 @@
 #include <sys/time.h>
 #endif
 
+#if ENABLE_DTRACE
+#include <sys/sdt.h>
+#endif
+
 /* Deal with missing byte order macros */
 #include <sys/param.h>
 


### PR DESCRIPTION

We can see available tracepoints with bpftools using the bpftools command:
tplist-bpfcc -vv -l /path/to/libtrace.so
    
Different tracepoints can be used to gain insights into how the application is performing, E.G. we can generate a histogram with the number of packets received in each batch with XDP using:
bpftrace -e 'usdt:xdp_received_packets { @packets = lhist(arg0, 0, 64, 2); }' -p PID