### PR TITLE
DAG25 fixes

### DIFF
--- a/lib/format_dag25.c
+++ b/lib/format_dag25.c
@@ -322,6 +322,9 @@ static void dag_close_device(struct dag_dev_t *dev)
 			dev->next->prev = dev->prev;
 	}
 
+	if (dev->dev_name)
+		free(dev->dev_name);
+
 	dag_close(dev->fd);
 	free(dev);
 }
@@ -881,7 +884,6 @@ static int dag_fin_input(libtrace_t *libtrace)
 	/* Close the DAG device if there are no more references to it */
 	if (FORMAT_DATA->device->ref_count == 0)
 		dag_close_device(FORMAT_DATA->device);
-
 	if (DUCK.dummy_duck)
 		trace_destroy_dead(DUCK.dummy_duck);
 

--- a/lib/format_dag25.c
+++ b/lib/format_dag25.c
@@ -1155,7 +1155,7 @@ static int dag_dump_packet(libtrace_out_t *libtrace,
 	uint16_t rlen = ntohs(erfptr->rlen);
 
         payload_size = rlen - (dag_record_size + pad);
-        alignment_pad = rlen % sizeof(uint64_t);
+        alignment_pad = sizeof(uint64_t) - (rlen % sizeof(uint64_t));
 	// update record length with any required padding
 	erfptr->rlen = htons(rlen + alignment_pad);
 


### PR DESCRIPTION
Re-adds batch output and implements dag_flush_output()
Replaces deprecated function dag_tx_stream_commit_bytes() with dag_tx_stream_commit_bytes64()
Fixes memory leak in dag dev_name