### PR TITLE
Issue #157: tracertstats should be able to be run against a file in non-tracetime

### DIFF
--- a/tools/tracertstats/tracertstats.c
+++ b/tools/tracertstats/tracertstats.c
@@ -77,7 +77,7 @@ struct filter_t {
 } *filters = NULL;
 
 uint64_t packet_count=UINT64_MAX;
-double packet_interval=UINT32_MAX;
+uint64_t packet_interval=UINT64_MAX;
 pthread_mutex_t ts_lock;
 uint64_t first_ts;
 
@@ -255,7 +255,7 @@ static libtrace_packet_t *cb_packet(libtrace_t *trace, libtrace_thread_t *t,
 		trace_publish_result(trace, t, td->last_key,
                                 tmp, RESULT_USER);
                 trace_post_reporter(trace);
-                td->last_key += (uint64_t)packet_interval << 32;
+                td->last_key += packet_interval << 32;
                 td->results = calloc(1, sizeof(result_t) +
                                 sizeof(statistic_t) * filter_count);
         }
@@ -297,7 +297,7 @@ static void cb_tick(libtrace_t *trace, libtrace_thread_t *t,
                 libtrace_generic_t tmp = {.ptr = td->results};
                 trace_publish_result(trace, t, td->last_key, tmp, RESULT_USER);
                 trace_post_reporter(trace);
-                td->last_key += (uint64_t)packet_interval << 32;
+                td->last_key += packet_interval << 32;
                 td->results = calloc(1, sizeof(result_t) +
                                 sizeof(statistic_t) * filter_count);
         }
@@ -450,7 +450,7 @@ int main(int argc, char *argv[]) {
                                         threadcount = 1;
                                 break;
 			case 'i':
-				packet_interval=atof(optarg);
+				packet_interval=strtoul(optarg, NULL, 10);
 				break;
 			case 'c':
 				packet_count=strtoul(optarg, NULL, 10);
@@ -475,7 +475,7 @@ int main(int argc, char *argv[]) {
 		}
 	}
 
-	if (packet_count == UINT64_MAX && packet_interval == UINT32_MAX) {
+	if (packet_count == UINT64_MAX && packet_interval == UINT64_MAX) {
 		packet_interval = 60; /* every minute */
 	}
 

--- a/tools/tracertstats/tracertstats.c
+++ b/tools/tracertstats/tracertstats.c
@@ -226,9 +226,9 @@ static inline void sync_first_key(uint64_t key, thread_data_t *td) {
         // used to sync intervals between perpkt threads
 	    if (first_ts == 0) {
 	            pthread_mutex_lock(&ts_lock);
-                        if (first_ts == 0) {
-                                first_ts = key;
-                        }
+                if (first_ts == 0) {
+                        first_ts = key;
+                }
                 pthread_mutex_unlock(&ts_lock);
 		}
         if (td->last_key == 0) {


### PR DESCRIPTION
This changes the default behaviour of tracertstats to process non live formats as fast possible.
Adds the -r, --realtime flag should the user wish to process in realtime.

This also will sync the first timestamp between different threads. This keeps results consistent when running with 1 or more threads.