### PR TITLE
Hold packet

### DIFF
--- a/lib/format_pcap.c
+++ b/lib/format_pcap.c
@@ -478,7 +478,7 @@ static int pcap_read_packet(libtrace_t *libtrace, libtrace_packet_t *packet) {
 		ret = pcap_next_ex(INPUT.pcap, &pcap_hdr, 
 				(const u_char **)&pcap_payload);
 		
-		packet->buffer = NULL;
+		packet->buffer = pcap_hdr;
 		packet->header = pcap_hdr;
 		packet->payload = pcap_payload;
 		packet->buf_control = TRACE_CTRL_EXTERNAL;

--- a/lib/trace_parallel.c
+++ b/lib/trace_parallel.c
@@ -1009,7 +1009,7 @@ static int trace_pread_packet_first_in_first_served(libtrace_t *libtrace,
              * if format module manages its own buffers that may be reused before the packet is
              * finised.
              */
-            libtrace_hold_packet(packet);
+            libtrace_hold_packet(packets[i]);
         }
 		/*
 		if (libtrace->config.tick_count && trace_packet_get_order(packets[i]) % libtrace->config.tick_count == 0) {


### PR DESCRIPTION
Fixes incorrect buf_control set using the pcap format.

Add call to libtrace_hold_packet() when using a single input stream with multiple perpkt threads or when libtrace is hashing packets. This will allow the format to handle reserving the packets buffer if it can but will fallback to copying the packet if not support by the format module.





