### PR TITLE
vDAG support

### DIFF
--- a/lib/format_dag25.c
+++ b/lib/format_dag25.c
@@ -951,8 +951,8 @@ static int dag_fin_output(libtrace_out_t *libtrace)
 	int out;
 	/* Wait until the buffer is clear before exiting the program,
 	 * as we will lose packets otherwise */
-	while((out = dag_get_stream_buffer_level(FORMAT_DATA_OUT->device->fd,
-	                                         FORMAT_DATA_OUT->dagstream))) {
+	while((out = dag_get_stream_buffer_level64(FORMAT_DATA_OUT->device->fd,
+	                                           FORMAT_DATA_OUT->dagstream))) {
 		/* Wait for dag to complete writing all data */
 
 		/* for some reason when writing to a vDAG dag_get_stream_buffer_level64

--- a/lib/format_dag25.c
+++ b/lib/format_dag25.c
@@ -666,6 +666,18 @@ static int dag_start_output(libtrace_out_t *libtrace)
 	zero.tv_usec = 0;
 	nopoll = zero;
 
+	/* if trying to perform TX on a RX stream (rx streams are even numbers)
+	 * put the card in reverse mode. */
+	if (FORMAT_DATA_OUT->dagstream % 2 == 0) {
+		// @param mode DAG_REVERSE_MODE (1) or DAG_NORMAL_MODE (0)
+		if (dag_set_mode(FORMAT_DATA_OUT->device->fd,
+			FORMAT_DATA_OUT->dagstream, 1) != 0) {
+
+			trace_set_err_out(libtrace, errno, "Cannot set DAG reverse mode");
+			return -1;
+		}
+	}
+
 	/* Attach and start the DAG stream */
 	if (dag_attach_stream64(FORMAT_DATA_OUT->device->fd,
 			FORMAT_DATA_OUT->dagstream, 0, TX_EXTRA_WINDOW) < 0) {
@@ -697,6 +709,18 @@ static int dag_start_input_stream(libtrace_t *libtrace,
 	zero.tv_sec = 0;
 	zero.tv_usec = 10000;
 	nopoll = zero;
+
+	/* if trying to perform RX on a TX stream (tx streams are even odd numbers)
+	 * put the card in reverse mode. */
+	if (stream->dagstream % 2 != 0) {
+		// @param mode DAG_REVERSE_MODE (1) or DAG_NORMAL_MODE (0)
+		if (dag_set_mode(FORMAT_DATA->device->fd,
+			stream->dagstream, 1) != 0) {
+
+			trace_set_err(libtrace, errno, "Cannot set DAG reverse mode");
+			return -1;
+		}
+	}
 
 	/* Attach and start the DAG stream */
 	if (dag_attach_stream64(FORMAT_DATA->device->fd,


### PR DESCRIPTION
This adds support for vDAG reading/writing. The stream is opened in reverse mode when trying to TX on a RX stream of when trying to RX on a TX stream, this is a requirement when using a vDAG.

Replaces dag_tx_stream_commit_bytes64() with dag_tx_stream_commit_records64(). Both behave the same when writing to a DAG device but dag_tx_stream_commit_records64() I could only get dag_tx_stream_commit_records64() working when using a vDAG.


