### PR TITLE
Only link against mlx4/5 ibverbs when required

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -666,16 +666,20 @@ if test "$want_dpdk" != no; then
 	# So instead simply check for existence
 	if test "$dpdk_found" = 0 -a "$RTE_SDK" != ""; then
 		AC_CHECK_FILE("$RTE_SDK/$RTE_TARGET/lib/libdpdk.so", dpdk_found="dpdk", dpdk_found=0)
+		AC_SUBST(DPDK_STATIC, 0)
 	fi
 	if test "$dpdk_found" = 0 -a "$RTE_SDK" != ""; then
 		AC_CHECK_FILE("$RTE_SDK/$RTE_TARGET/lib/libintel_dpdk.a", dpdk_found=":libintel_dpdk.a", dpdk_found=0)
+		AC_SUBST(DPDK_STATIC, 1)
 	fi
 	# DPDK 2.1.0+ renames this to libdpdk from libintel_dpdk
 	if test "$dpdk_found" = 0 -a "$RTE_SDK" != ""; then
 		AC_CHECK_FILE("$RTE_SDK/$RTE_TARGET/lib/libdpdk.a", dpdk_found=":libdpdk.a", dpdk_found=0)
+		AC_SUBST(DPDK_STATIC, 1)
 	fi
 	if test "$dpdk_found" = 0 -a "$RTE_SDK" != ""; then
 		AC_CHECK_LIB(dpdk, rte_eth_dev_configure, dpdk_found="dpdk", dpdk_found=0)
+		AC_SUBST(DPDK_STATIC, 0)
 	fi
 	if test "$dpdk_found" != 0 -a "$RTE_SDK" != ""; then
 		# Save these now so that they can be re-exported later
@@ -709,6 +713,7 @@ if test "$want_dpdk" != no; then
                         # Used to load the correct DPDK version when not statically linked
                         DPDK_LIBS="-Wl,-z,defs $(echo $DPDK_LIBS | sed -E 's!-L(/[[^ ]]*)!-R\1 -L\1!g')"
                         unset PKG_CONFIG_PATH
+                        AC_SUBST(DPDK_STATIC, 1)
                 fi
         fi
 
@@ -736,6 +741,7 @@ if test "$want_dpdk" != no; then
                 PKG_PROG_PKG_CONFIG
                 PKG_CHECK_MODULES([DPDK], [libdpdk >= 18], [pkgconf_dpdk_found="yes"],
                                   [pkgconf_dpdk_found="no"])
+                AC_SUBST(DPDK_STATIC, 0)
         fi
         # DPDK has been using pkgconf (user-defined or system path)
         if test "$dpdk_found" = 0 -a "x$pkgconf_dpdk_found" = "xyes"; then
@@ -795,6 +801,7 @@ if test "$want_dpdk" != no; then
 
 				dpdk_found=system
 				dpdk_path=system
+				AC_SUBST(DPDK_STATIC, 0)
 			fi
 		fi
 	fi

--- a/lib/dpdk_libtrace.mk
+++ b/lib/dpdk_libtrace.mk
@@ -13,11 +13,13 @@ ifeq ($(CONFIG_RTE_LIBC),y)
 DPDKLIBS += -Wl,-lc -Wl,-lm
 endif
 
+ifeq ($(DPDK_STATIC), 1)
 ifeq ($(CONFIG_RTE_LIBRTE_MLX4_PMD), y)
 DPDKLIBS += -Wl,-libverbs -Wl,-lmlx4 -Wl,-ldl
 endif
 ifeq ($(CONFIG_RTE_LIBRTE_MLX5_PMD), y)
 DPDKLIBS += -Wl,-libverbs -Wl,-lmlx5 -Wl,-ldl
+endif
 endif
 
 DPDKLIBS += $(addprefix -Wl$(comma),$(EXECENV_LDLIBS))


### PR DESCRIPTION
Improvement to only link against mlx4, mlx5, and ibverbs when statically linking against DPDK. As these libraries are not needed when linking against a shared library and as it unnecessarily requires the user to install the libibverbs-dev to build libtrace.