### PR TITLE
Fix pausing parallel DAG input

### DIFF
--- a/lib/format_dag25.c
+++ b/lib/format_dag25.c
@@ -782,59 +782,59 @@ static int dag_pstart_input(libtrace_t *libtrace)
 	struct dag_per_stream_t stream_data;
         libtrace_list_node_t *streams = FORMAT_DATA_HEAD;
 
-	/* Check we aren't trying to create more threads than the DAG card can
-	 * handle */
-	max_streams = dag_rx_get_stream_count(FORMAT_DATA->device->fd);
-	if (libtrace->perpkt_thread_count > max_streams) {
-		fprintf(stderr,
-			      "WARNING: DAG has only %u streams available, "
-                              "capping total number of threads at this value.",
-			      max_streams);
-	        libtrace->perpkt_thread_count = max_streams;
+        /* Check we aren't trying to create more threads than the DAG card can
+         * handle */
+        max_streams = dag_rx_get_stream_count(FORMAT_DATA->device->fd);
+        if (libtrace->perpkt_thread_count > max_streams) {
+                fprintf(stderr,
+                        "WARNING: DAG has only %u streams available, "
+                        "capping total number of threads at this value.",
+                        max_streams);
+                libtrace->perpkt_thread_count = max_streams;
         }
 
-	/* Get the stream names from the uri */
-	if ((scan = strchr(libtrace->uridata, ',')) == NULL) {
-		trace_set_err(libtrace, TRACE_ERR_BAD_FORMAT,
-			      "Format uri doesn't specify the DAG streams");
-		iserror = 1;
-		goto cleanup;
-	}
+        /* Get the stream names from the uri */
+        if ((scan = strchr(libtrace->uridata, ',')) == NULL) {
+                trace_set_err(libtrace, TRACE_ERR_BAD_FORMAT,
+                              "Format uri doesn't specify the DAG streams");
+                iserror = 1;
+                goto cleanup;
+        }
 
-	scan++;
+        scan++;
 
-	tok = strtok(scan, ",");
-	while (tok != NULL) {
-		/* Ensure we haven't specified too many streams */
-		if (stream_count >= libtrace->perpkt_thread_count) {
-			fprintf(stderr,
-				      "WARNING: Format uri specifies too many "
-                                      "streams. Maximum is %u, so only using "
-                                      "the first %u from the uri.",
-                                      libtrace->perpkt_thread_count, 
-				      libtrace->perpkt_thread_count);
-		        break;
+        tok = strtok(scan, ",");
+        while (tok != NULL) {
+                /* Ensure we haven't specified too many streams */
+                if (stream_count >= libtrace->perpkt_thread_count) {
+                        fprintf(stderr,
+                                "WARNING: Format uri specifies too many "
+                                "streams. Maximum is %u, so only using "
+                                "the first %u from the uri.",
+                                libtrace->perpkt_thread_count,
+                                libtrace->perpkt_thread_count);
+                        break;
                 }
 
-		/* Save the stream details */
-		if (stream_count == 0) {
-			/* Special case where we update the existing stream
-			 * data structure */
-			FORMAT_DATA_FIRST->dagstream = (uint16_t)atoi(tok);
-		} else {
-			memset(&stream_data, 0, sizeof(stream_data));
-			stream_data.dagstream = (uint16_t)atoi(tok);
-			libtrace_list_push_back(FORMAT_DATA->per_stream,
-						&stream_data);
-		}
+                /* Save the stream details */
+                if (stream_count == 0) {
+                        /* Special case where we update the existing stream
+                         * data structure */
+                        FORMAT_DATA_FIRST->dagstream = (uint16_t)atoi(tok);
+                } else {
+                        memset(&stream_data, 0, sizeof(stream_data));
+                        stream_data.dagstream = (uint16_t)atoi(tok);
+                        libtrace_list_push_back(FORMAT_DATA->per_stream,
+                                                &stream_data);
+                }
 
-		stream_count++;
-		tok = strtok(NULL, ",");
-	}
+                stream_count++;
+                tok = strtok(NULL, ",");
+        }
 
-	if (stream_count < libtrace->perpkt_thread_count) {
-		libtrace->perpkt_thread_count = stream_count;
-	}
+        if (stream_count < libtrace->perpkt_thread_count) {
+                libtrace->perpkt_thread_count = stream_count;
+        }
 
         /* Attach and start each DAG stream */
         while (streams != NULL) {
@@ -845,7 +845,6 @@ static int dag_pstart_input(libtrace_t *libtrace)
         }
 
         FORMAT_DATA->stream_attached = 1;
-
 
  cleanup:
 	if (iserror) {

--- a/test/do-live-tests.sh
+++ b/test/do-live-tests.sh
@@ -165,12 +165,12 @@ done
 
 for r in "${dag_formats[@]}"
 do
-	do_parallel_test ./test-format-parallel "$r" "dag:/dev/dag16,0" "-p"
-	do_parallel_test ./test-format-parallel-hasher "$r" "dag:/dev/dag16,0" "-p"
+	do_parallel_test ./test-format-parallel "$r" "dag:/dev/dag16,0"
+	do_parallel_test ./test-format-parallel-hasher "$r" "dag:/dev/dag16,0"
 	# TODO fix test-format-parallel-reporter for live input
-        #do_parallel_test ./test-format-parallel-reporter "$r" "dag:/dev/dag16,0" "-p"
-	do_parallel_test ./test-format-parallel-singlethreaded "$r" "dag:/dev/dag16,0" "-p"
-	do_parallel_test ./test-format-parallel-singlethreaded-hasher "$r" "dag:/dev/dag16,0" "-p"
+        #do_parallel_test ./test-format-parallel-reporter "$r" "dag:/dev/dag16,0"
+	do_parallel_test ./test-format-parallel-singlethreaded "$r" "dag:/dev/dag16,0"
+	do_parallel_test ./test-format-parallel-singlethreaded-hasher "$r" "dag:/dev/dag16,0"
 done
 echo
 echo "Single threaded API tests passed: $OK"


### PR DESCRIPTION
This moves starting a parallel DAG stream to the start_input callback.
Enables test to pause parallel DAG input.