### PR TITLE
PF_RING updates

### DIFF
--- a/lib/format_linux_common.c
+++ b/lib/format_linux_common.c
@@ -441,12 +441,13 @@ int linuxcommon_start_input_stream(libtrace_t *libtrace,
 	FORMAT_DATA->stats.tp_packets = -count;
 	FORMAT_DATA->stats.tp_drops = 0;
 
-	if (linux_get_dev_statistics(libtrace->uridata, &FORMAT_DATA->dev_stats) != 0) {
-		/* Mark this as bad */
-		FORMAT_DATA->dev_stats.if_name[0] = 0;
-	}
+        if (linux_get_dev_statistics(libtrace->uridata,
+                                     &FORMAT_DATA->dev_stats) != 0) {
+                /* Mark this as bad */
+                FORMAT_DATA->dev_stats.if_name[0] = 0;
+        }
 
-	return 0;
+        return 0;
 }
 
 int linuxcommon_pause_input(libtrace_t *libtrace)
@@ -553,49 +554,48 @@ void linuxcommon_get_statistics(libtrace_t *libtrace, libtrace_stat_t *stat) {
 	dev_stats.if_name[0] = 0; /* This will be set if we retrive valid stats */
 	/* Do we have starting stats to compare to? */
 	if (FORMAT_DATA->dev_stats.if_name[0] != 0) {
-		linux_get_dev_statistics(libtrace->uridata, &dev_stats);
-	}
-	linuxcommon_update_socket_statistics(libtrace);
+                linux_get_dev_statistics(libtrace->uridata, &dev_stats);
+        }
+        linuxcommon_update_socket_statistics(libtrace);
 
-	/* filtered count == dev received - socket received */
-	if (FORMAT_DATA->filter != NULL &&
-	    FORMAT_DATA->stats_valid &&
-	    dev_stats.if_name[0]) {
-		uint64_t filtered = DEV_DIFF(rx_packets) -
-		                    FORMAT_DATA->stats.tp_packets;
-		/* Check the value is sane, due to timing it could be below 0 */
-		if (filtered < UINT64_MAX - 100000) {
-			stat->filtered += filtered;
-		}
-	}
+        /* filtered count == dev received - socket received */
+        if (FORMAT_DATA->filter != NULL && FORMAT_DATA->stats_valid &&
+            dev_stats.if_name[0]) {
+                uint64_t filtered =
+                    DEV_DIFF(rx_packets) - FORMAT_DATA->stats.tp_packets;
+                /* Check the value is sane, due to timing it could be below 0 */
+                if (filtered < UINT64_MAX - 100000) {
+                        stat->filtered += filtered;
+                }
+        }
 
-	/* dropped count == socket dropped + dev dropped */
-	if (FORMAT_DATA->stats_valid) {
-		stat->dropped_valid = 1;
-		stat->dropped = FORMAT_DATA->stats.tp_drops;
-		if (dev_stats.if_name[0]) {
-			stat->dropped += DEV_DIFF(rx_drops);
-		}
-	}
+        /* dropped count == socket dropped + dev dropped */
+        if (FORMAT_DATA->stats_valid) {
+                stat->dropped_valid = 1;
+                stat->dropped = FORMAT_DATA->stats.tp_drops;
+                if (dev_stats.if_name[0]) {
+                        stat->dropped += DEV_DIFF(rx_drops);
+                }
+        }
 
-	/* received count - All good packets even those dropped or filtered */
-	if (dev_stats.if_name[0]) {
-		stat->received_valid = 1;
-		stat->received = DEV_DIFF(rx_packets) + DEV_DIFF(rx_drops);
-	}
+        /* received count - All good packets even those dropped or filtered */
+        if (dev_stats.if_name[0]) {
+                stat->received_valid = 1;
+                stat->received = DEV_DIFF(rx_packets) + DEV_DIFF(rx_drops);
+        }
 
-	/* captured count - received and but not dropped */
-	if (dev_stats.if_name[0] && FORMAT_DATA->stats_valid) {
-		stat->captured_valid = 1;
-		stat->captured = DEV_DIFF(rx_packets) - FORMAT_DATA->stats.tp_drops;
-	}
+        /* captured count - received and but not dropped */
+        if (dev_stats.if_name[0] && FORMAT_DATA->stats_valid) {
+                stat->captured_valid = 1;
+                stat->captured =
+                    DEV_DIFF(rx_packets) - FORMAT_DATA->stats.tp_drops;
+        }
 
-	/* errors */
-	if (dev_stats.if_name[0]) {
-		stat->errors_valid = 1;
-		stat->errors = DEV_DIFF(rx_errors);
-	}
-
+        /* errors */
+        if (dev_stats.if_name[0]) {
+                stat->errors_valid = 1;
+                stat->errors = DEV_DIFF(rx_errors);
+        }
 }
 
 int linuxcommon_get_fd(const libtrace_t *libtrace) {

--- a/lib/format_linux_common.h
+++ b/lib/format_linux_common.h
@@ -38,6 +38,7 @@
 #include "libtrace.h"
 #include "libtrace_int.h"
 #include "libtrace_arphrd.h"
+#include "format_linux_helpers.h"
 
 #ifdef HAVE_NETPACKET_PACKET_H
 
@@ -198,29 +199,6 @@ struct tpacket_req {
 #define IF_NAMESIZE 16
 #endif
 
-/* A structure we use to hold statistic counters from the network cards
- * as accessed via the /proc/net/dev
- */
-struct linux_dev_stats {
-	char if_name[IF_NAMESIZE];
-	uint64_t rx_bytes;
-	uint64_t rx_packets;
-	uint64_t rx_errors;
-	uint64_t rx_drops;
-	uint64_t rx_fifo;
-	uint64_t rx_frame;
-	uint64_t rx_compressed;
-	uint64_t rx_multicast;
-	uint64_t tx_bytes;
-	uint64_t tx_packets;
-	uint64_t tx_errors;
-	uint64_t tx_drops;
-	uint64_t tx_fifo;
-	uint64_t tx_colls;
-	uint64_t tx_carrier;
-	uint64_t tx_compressed;
-};
-
 /* Note that this structure is passed over the wire in rt encapsulation, and
  * thus we need to be careful with data sizes.  timeval's and timespec's
  * can also change their size on 32/64 machines.
@@ -352,7 +330,6 @@ int linuxcommon_pstart_input(libtrace_t *libtrace,
 #endif /* HAVE_NETPACKET_PACKET_H */
 
 void linuxcommon_get_statistics(libtrace_t *libtrace, libtrace_stat_t *stat);
-int linuxcommon_get_dev_statistics(char *ifname, struct linux_dev_stats *stats);
 
 static inline libtrace_direction_t linuxcommon_get_direction(uint8_t pkttype)
 {

--- a/lib/format_linux_helpers.c
+++ b/lib/format_linux_helpers.c
@@ -243,12 +243,13 @@ int linux_set_nic_rx_tx_rings(int tx, int rx, char *ifname) {
 #define str(s) #s
 
 /* These don't typically reset however an interface does exist to reset them */
-int linux_get_dev_statistics(char *ifname, struct linux_dev_stats *stats) {
+int linux_get_dev_statistics(char *ifname, struct linux_dev_stats *stats)
+{
         FILE *file;
         char line[1024];
         struct linux_dev_stats tmp_stats;
 
-        file = fopen("/proc/net/dev","r");
+        file = fopen("/proc/net/dev", "r");
         if (file == NULL) {
                 return -1;
         }
@@ -264,29 +265,22 @@ int linux_get_dev_statistics(char *ifname, struct linux_dev_stats *stats) {
                 return -1;
         }
 
-        while (!(feof(file)||ferror(file))) {
+        while (!(feof(file) || ferror(file))) {
                 int tot;
                 if (fgets(line, sizeof(line), file) == NULL)
                         break;
 
-                tot = sscanf(line, " %"xstr(IF_NAMESIZE)"[^:]:" REPEAT_16(" %"SCNd64),
-                             tmp_stats.if_name,
-                             &tmp_stats.rx_bytes,
-                             &tmp_stats.rx_packets,
-                             &tmp_stats.rx_errors,
-                             &tmp_stats.rx_drops,
-                             &tmp_stats.rx_fifo,
-                             &tmp_stats.rx_frame,
-                             &tmp_stats.rx_compressed,
-                             &tmp_stats.rx_multicast,
-                             &tmp_stats.tx_bytes,
-                             &tmp_stats.tx_packets,
-                             &tmp_stats.tx_errors,
-                             &tmp_stats.tx_drops,
-                             &tmp_stats.tx_fifo,
-                             &tmp_stats.tx_colls,
-                             &tmp_stats.tx_carrier,
-                             &tmp_stats.tx_compressed);
+                tot = sscanf(
+                    line, " %" xstr(IF_NAMESIZE) "[^:]:" REPEAT_16(" %" SCNd64),
+                    tmp_stats.if_name, &tmp_stats.rx_bytes,
+                    &tmp_stats.rx_packets, &tmp_stats.rx_errors,
+                    &tmp_stats.rx_drops, &tmp_stats.rx_fifo,
+                    &tmp_stats.rx_frame, &tmp_stats.rx_compressed,
+                    &tmp_stats.rx_multicast, &tmp_stats.tx_bytes,
+                    &tmp_stats.tx_packets, &tmp_stats.tx_errors,
+                    &tmp_stats.tx_drops, &tmp_stats.tx_fifo,
+                    &tmp_stats.tx_colls, &tmp_stats.tx_carrier,
+                    &tmp_stats.tx_compressed);
                 if (tot != 17)
                         continue;
                 if (strncmp(tmp_stats.if_name, ifname, IF_NAMESIZE) == 0) {

--- a/lib/format_linux_helpers.c
+++ b/lib/format_linux_helpers.c
@@ -237,3 +237,64 @@ int linux_set_nic_rx_tx_rings(int tx, int rx, char *ifname) {
         return -1;
     return 1;
 }
+
+#define REPEAT_16(x) x x x x x x x x x x x x x x x x
+#define xstr(s) str(s)
+#define str(s) #s
+
+/* These don't typically reset however an interface does exist to reset them */
+int linux_get_dev_statistics(char *ifname, struct linux_dev_stats *stats) {
+        FILE *file;
+        char line[1024];
+        struct linux_dev_stats tmp_stats;
+
+        file = fopen("/proc/net/dev","r");
+        if (file == NULL) {
+                return -1;
+        }
+
+        /* Skip 2 header lines */
+        if (fgets(line, sizeof(line), file) == NULL) {
+                fclose(file);
+                return -1;
+        }
+
+        if (fgets(line, sizeof(line), file) == NULL) {
+                fclose(file);
+                return -1;
+        }
+
+        while (!(feof(file)||ferror(file))) {
+                int tot;
+                if (fgets(line, sizeof(line), file) == NULL)
+                        break;
+
+                tot = sscanf(line, " %"xstr(IF_NAMESIZE)"[^:]:" REPEAT_16(" %"SCNd64),
+                             tmp_stats.if_name,
+                             &tmp_stats.rx_bytes,
+                             &tmp_stats.rx_packets,
+                             &tmp_stats.rx_errors,
+                             &tmp_stats.rx_drops,
+                             &tmp_stats.rx_fifo,
+                             &tmp_stats.rx_frame,
+                             &tmp_stats.rx_compressed,
+                             &tmp_stats.rx_multicast,
+                             &tmp_stats.tx_bytes,
+                             &tmp_stats.tx_packets,
+                             &tmp_stats.tx_errors,
+                             &tmp_stats.tx_drops,
+                             &tmp_stats.tx_fifo,
+                             &tmp_stats.tx_colls,
+                             &tmp_stats.tx_carrier,
+                             &tmp_stats.tx_compressed);
+                if (tot != 17)
+                        continue;
+                if (strncmp(tmp_stats.if_name, ifname, IF_NAMESIZE) == 0) {
+                        *stats = tmp_stats;
+                        fclose(file);
+                        return 0;
+                }
+        }
+        fclose(file);
+        return -1;
+}

--- a/lib/format_linux_helpers.h
+++ b/lib/format_linux_helpers.h
@@ -4,6 +4,31 @@
 #include "libtrace.h"
 #include "libtrace_int.h"
 
+#include <net/if.h>
+
+/* A structure we use to hold statistic counters from the network cards
+ * as accessed via the /proc/net/dev
+ */
+struct linux_dev_stats {
+        char if_name[IF_NAMESIZE];
+        uint64_t rx_bytes;
+        uint64_t rx_packets;
+        uint64_t rx_errors;
+        uint64_t rx_drops;
+        uint64_t rx_fifo;
+        uint64_t rx_frame;
+        uint64_t rx_compressed;
+        uint64_t rx_multicast;
+        uint64_t tx_bytes;
+        uint64_t tx_packets;
+        uint64_t tx_errors;
+        uint64_t tx_drops;
+        uint64_t tx_fifo;
+        uint64_t tx_colls;
+        uint64_t tx_carrier;
+        uint64_t tx_compressed;
+};
+
 int linux_set_nic_promisc(const int sock, const unsigned int ifindex, bool enable);
 int linux_get_nic_max_queues(char *ifname);
 int linux_get_nic_queues(char *ifname);
@@ -15,5 +40,6 @@ int linux_get_nic_tx_rings(char *ifname);
 int linux_get_nic_max_rx_rings(char *ifname);
 int linux_get_nic_max_tx_rings(char *ifname);
 int linux_set_nic_rx_tx_rings(int tx, int rx, char *ifname);
+int linux_get_dev_statistics(char *ifname, struct linux_dev_stats *stats);
 
 #endif

--- a/lib/format_linux_xdp.c
+++ b/lib/format_linux_xdp.c
@@ -539,7 +539,7 @@ static int linux_xdp_setup_xdp(libtrace_t *libtrace) {
     }
 
     // get the initial device stats
-    if (linuxcommon_get_dev_statistics(XDP_FORMAT_DATA->cfg.ifname, &XDP_FORMAT_DATA->cfg.stats) != 0) {
+    if (linux_get_dev_statistics(XDP_FORMAT_DATA->cfg.ifname, &XDP_FORMAT_DATA->cfg.stats) != 0) {
         XDP_FORMAT_DATA->cfg.stats.if_name[0] = 0;
     }
 
@@ -1393,7 +1393,7 @@ static void linux_xdp_get_stats(libtrace_t *libtrace, libtrace_stat_t *stats) {
 
     /* If we have the initial interface stats get the current and calculate the dropped packets */
     if (XDP_FORMAT_DATA->cfg.stats.if_name[0] != 0) {
-        if (linuxcommon_get_dev_statistics(XDP_FORMAT_DATA->cfg.ifname, &dev_stats) == 0) {
+        if (linux_get_dev_statistics(XDP_FORMAT_DATA->cfg.ifname, &dev_stats) == 0) {
             stats->dropped += (dev_stats.rx_drops - XDP_FORMAT_DATA->cfg.stats.rx_drops);
             stats->dropped_valid = 1;
             /* Received comes from the BPF program i.e. kernel

--- a/lib/format_linux_xdp.c
+++ b/lib/format_linux_xdp.c
@@ -539,8 +539,9 @@ static int linux_xdp_setup_xdp(libtrace_t *libtrace) {
     }
 
     // get the initial device stats
-    if (linux_get_dev_statistics(XDP_FORMAT_DATA->cfg.ifname, &XDP_FORMAT_DATA->cfg.stats) != 0) {
-        XDP_FORMAT_DATA->cfg.stats.if_name[0] = 0;
+    if (linux_get_dev_statistics(XDP_FORMAT_DATA->cfg.ifname,
+                                 &XDP_FORMAT_DATA->cfg.stats) != 0) {
+            XDP_FORMAT_DATA->cfg.stats.if_name[0] = 0;
     }
 
     /* cfg.promisc will be 1 if the user has explicity set promisc to off,
@@ -1393,15 +1394,20 @@ static void linux_xdp_get_stats(libtrace_t *libtrace, libtrace_stat_t *stats) {
 
     /* If we have the initial interface stats get the current and calculate the dropped packets */
     if (XDP_FORMAT_DATA->cfg.stats.if_name[0] != 0) {
-        if (linux_get_dev_statistics(XDP_FORMAT_DATA->cfg.ifname, &dev_stats) == 0) {
-            stats->dropped += (dev_stats.rx_drops - XDP_FORMAT_DATA->cfg.stats.rx_drops);
-            stats->dropped_valid = 1;
-            /* Received comes from the BPF program i.e. kernel
-               Add card drops, but not drops between kernel and user-space */
-            stats->received += (dev_stats.rx_drops - XDP_FORMAT_DATA->cfg.stats.rx_drops);
-            stats->errors += (dev_stats.rx_errors - XDP_FORMAT_DATA->cfg.stats.rx_errors);
-            stats->errors_valid = 1;
-        }
+            if (linux_get_dev_statistics(XDP_FORMAT_DATA->cfg.ifname,
+                                         &dev_stats) == 0) {
+                    stats->dropped += (dev_stats.rx_drops -
+                                       XDP_FORMAT_DATA->cfg.stats.rx_drops);
+                    stats->dropped_valid = 1;
+                    /* Received comes from the BPF program i.e. kernel
+                       Add card drops, but not drops between kernel and
+                       user-space */
+                    stats->received += (dev_stats.rx_drops -
+                                        XDP_FORMAT_DATA->cfg.stats.rx_drops);
+                    stats->errors += (dev_stats.rx_errors -
+                                      XDP_FORMAT_DATA->cfg.stats.rx_errors);
+                    stats->errors_valid = 1;
+            }
     }
 
     if (stats->received_valid && stats->dropped_valid) {

--- a/lib/format_pfring.c
+++ b/lib/format_pfring.c
@@ -65,6 +65,7 @@ struct pfring_format_data_t {
 	int snaplen;
 	int8_t ringenabled;
 	char *bpffilter;
+        struct linux_dev_stats interface_stats;
 };
 
 struct pfringzc_per_thread {
@@ -84,6 +85,7 @@ struct pfringzc_format_data_t {
 	int snaplen;
 	char *bpffilter;
 	enum hasher_types hashtype;
+	struct linux_dev_stats interface_stats;
 };
 
 struct pfring_per_stream_t {
@@ -324,6 +326,7 @@ static int pfringzc_max_packet_length(char *device) {
 static int pfringzc_configure_interface(char *uridata,
                                         int threads,
                                         bool dedicated_hasher,
+                                        struct linux_dev_stats *stats,
                                         char *err,
                                         int errlen) {
 	char *interface = pfring_ifname_from_uridata(uridata);
@@ -345,6 +348,11 @@ static int pfringzc_configure_interface(char *uridata,
                         return -1;
 		}
 	}
+        // get initial interface statistics
+        if (linux_get_dev_statistics(interface, stats) != 0) {
+                stats->if_name[0] = 0;
+        }
+
         return threads;
 }
 
@@ -359,6 +367,7 @@ static int pfringzc_start_input(libtrace_t *libtrace) {
         if ((threads = pfringzc_configure_interface(libtrace->uridata,
                                                     libtrace->perpkt_thread_count,
                                                     trace_has_dedicated_hasher(libtrace),
+                                                    &(ZC_FORMAT_DATA->interface_stats),
                                                     err,
                                                     sizeof(err))) == -1) {
                 trace_set_err(libtrace, errno, "%s", err);
@@ -378,6 +387,7 @@ static int pfringzc_start_input(libtrace_t *libtrace) {
                 trace_set_err(libtrace, errno, "%s", err);
 		return -1;
         }
+
 	return 0;
 }
 
@@ -392,6 +402,7 @@ static int pfringzc_start_output(libtrace_out_t *libtrace) {
         if ((threads = pfringzc_configure_interface(libtrace->uridata,
                                                     1,
                                                     0,
+                                                    &(ZC_FORMAT_DATA->interface_stats),
                                                     err,
                                                     sizeof(err))) == -1) {
                 trace_set_err_out(libtrace, errno, "%s", err);
@@ -411,6 +422,7 @@ static int pfringzc_start_output(libtrace_out_t *libtrace) {
                 trace_set_err_out(libtrace, errno, "%s", err);
                 return -1;
         }
+
         return 0;
 }
 
@@ -439,8 +451,16 @@ static int pfring_start_input(libtrace_t *libtrace) {
 
 	rc = pfring_start_input_stream(libtrace, FORMAT_DATA_FIRST);
 	if (rc < 0)
-		return rc;	
+		return rc;
+
 	FORMAT_DATA->ringenabled = 1;
+
+        // get initial interface statistics
+        if (linux_get_dev_statistics(pfring_ifname_from_uridata(libtrace->uridata),
+                                     &(FORMAT_DATA->interface_stats)) != 0) {
+                FORMAT_DATA->interface_stats.if_name[0] = 0;
+        }
+
 	return rc;
 }
 
@@ -509,6 +529,13 @@ static int pfring_pstart_input(libtrace_t *libtrace) {
 		return -1;
 	}
 	FORMAT_DATA->ringenabled = 1;
+
+        // get initial interface statistics
+        if (linux_get_dev_statistics(pfring_ifname_from_uridata(libtrace->uridata),
+                                     &(FORMAT_DATA->interface_stats)) != 0) {
+                FORMAT_DATA->interface_stats.if_name[0] = 0;
+        }
+
 	return 0;
 }
 
@@ -1075,8 +1102,13 @@ static size_t pfring_set_capture_length(libtrace_packet_t *packet, size_t size)
 static void pfring_get_statistics(libtrace_t *libtrace, libtrace_stat_t *stat) {
 
 	pfring_stat st;
-
+        struct linux_dev_stats dev_stats;
 	size_t i;
+
+        stat->dropped = 0;
+        stat->received = 0;
+        stat->errors = 0;
+        stat->captured = 0;
 
 	for (i = 0; i < libtrace_list_get_size(FORMAT_DATA->per_stream); ++i) {
 		struct pfring_per_stream_t *stream;
@@ -1087,20 +1119,33 @@ static void pfring_get_statistics(libtrace_t *libtrace, libtrace_stat_t *stat) {
 			continue;
 		}
 
-		if (stat->dropped_valid) {
-			stat->dropped += st.drop;
-		} else {
-			stat->dropped = st.drop;
-			stat->dropped_valid = 1;
-		}
-
-		if (stat->received_valid) {
-			stat->received += st.recv;
-		} else {
-			stat->received = st.recv;
-			stat->received_valid = 1;
-		}
+                // dropped between pfring and libtrace?
+		stat->dropped += st.drop;
 	}
+
+        if (FORMAT_DATA->interface_stats.if_name[0] != 0) {
+                if (linux_get_dev_statistics(pfring_ifname_from_uridata(libtrace->uridata),
+                                             &dev_stats) == 0) {
+
+                        // add card drops
+                        stat->dropped += (dev_stats.rx_drops - FORMAT_DATA->interface_stats.rx_drops);
+                        stat->dropped_valid = 1;
+
+                        // calculate recieved packets by the card, this includes dropped packets but not errored
+                        stat->received = (dev_stats.rx_packets - FORMAT_DATA->interface_stats.rx_packets);
+                        stat->received += (dev_stats.rx_drops - FORMAT_DATA->interface_stats.rx_drops);
+                        stat->received_valid = 1;
+
+                        // add card errors
+                        stat->errors = (dev_stats.rx_errors - FORMAT_DATA->interface_stats.rx_errors);
+                        stat->errors_valid = 1;
+                }
+        }
+
+        if (stat->received_valid && stat->dropped_valid) {
+               stat->captured = stat->received - stat->dropped;
+               stat->captured_valid = 1;
+        }
 
 }
 

--- a/lib/format_pfring.c
+++ b/lib/format_pfring.c
@@ -98,6 +98,7 @@ struct pfring_per_stream_t {
         x->dropped = 0; x->dropped_valid = 0;\
         x->received = 0; x->received_valid = 0;\
         x->captured = 0; x->captured_valid = 0;\
+	x->errors = 0; x->errors_valid = 0;\
 }
 
 #define ZERO_PFRING_STREAM {NULL, -1}

--- a/lib/format_pfring.c
+++ b/lib/format_pfring.c
@@ -1320,6 +1320,8 @@ static void pfringzc_get_stats(libtrace_t *libtrace,
 	// when using zero copy stats from pfring_zc_stats are correct however when not in zero copy we
 	// need to get stats from the card
 	if (!(ZC_FORMAT_DATA->zero_copy)) {
+		stats->received_valid = 0;
+                stats->dropped_valid = 0;
 		if (ZC_FORMAT_DATA->interface_stats.if_name[0] != 0) {
                 	if (linux_get_dev_statistics(pfring_ifname_from_uridata(libtrace->uridata),
                                                      &dev_stats) == 0) {

--- a/lib/format_pfring.c
+++ b/lib/format_pfring.c
@@ -349,10 +349,10 @@ static int pfringzc_configure_interface(char *uridata,
 	// set nic queues to match number of threads
 	if (linux_get_nic_queues(interface) != threads) {
 		if (linux_set_nic_queues(interface, threads) != threads) {
-                        snprintf(err, errlen, "Unable to set number of NIC queues to match the "
-                                "number of processing threads: %d", threads);
-			errno = TRACE_ERR_INIT_FAILED;
-                        return -1;
+                        fprintf(stderr, "Unable to set number of NIC queues to match the "
+                                "number of processing threads: %d, packets may be lost", threads);
+			//errno = TRACE_ERR_INIT_FAILED;
+                        //return -1;
 		}
 	}
         // get initial interface statistics

--- a/lib/format_pfring.c
+++ b/lib/format_pfring.c
@@ -93,6 +93,13 @@ struct pfring_per_stream_t {
 	int affinity;
 };
 
+#define ZERO_STATS(x) {\
+        x->dropped = 0; x->dropped_valid = 0;\
+        x->received = 0; x->received_valid = 0;\
+        x->errors = 0; x->errors_valid = 0;\
+        x->captured = 0; x->captured_valid = 0;\
+}
+
 #define ZERO_PFRING_STREAM {NULL, -1}
 
 #define PFRING_DATA(x) ((struct pfring_format_data_t *)x->format_data)
@@ -867,7 +874,7 @@ static int pfringzc_read_batch(libtrace_t *libtrace,
 		u_char *pkt_buf = pfring_zc_pkt_buff_data(stream->buffers[i], stream->device);
 
 		packet[i]->buf_control = TRACE_CTRL_EXTERNAL;
-		packet[i]->type = TRACE_RT_DATA_PFRINGZC;
+		packet[i]->type = TRACE_RT_DATA_PFRING;
 		packet[i]->buffer = stream->buffers[i];
 		packet[i]->header = stream->buffers[i]->user;
 		packet[i]->payload = pkt_buf;
@@ -960,7 +967,7 @@ static int pfring_read_generic(libtrace_t *libtrace, libtrace_packet_t *packet,
 	 */
 
 	packet->trace = libtrace;
-	packet->type = TRACE_RT_DATA_PFRING;
+	packet->type = TRACE_RT_DATA_PFRINGOLD;
 	packet->header = packet->buffer;
 	packet->error = 1;
 
@@ -1104,11 +1111,7 @@ static void pfring_get_statistics(libtrace_t *libtrace, libtrace_stat_t *stat) {
 	pfring_stat st;
         struct linux_dev_stats dev_stats;
 	size_t i;
-
-        stat->dropped = 0;
-        stat->received = 0;
-        stat->errors = 0;
-        stat->captured = 0;
+        ZERO_STATS(stat);
 
 	for (i = 0; i < libtrace_list_get_size(FORMAT_DATA->per_stream); ++i) {
 		struct pfring_per_stream_t *stream;
@@ -1271,31 +1274,50 @@ static int pfring_pregister_thread(libtrace_t *libtrace, libtrace_thread_t *t,
 
 static void pfringzc_get_stats(libtrace_t *libtrace,
 			       libtrace_stat_t *stats) {
-	int threads, i, rc;
+	int threads, i;
 	pfring_zc_stat zcstats;
+        struct linux_dev_stats dev_stats;
+        ZERO_STATS(stats);
+
 	if (libtrace->perpkt_thread_count == 0 || trace_has_dedicated_hasher(libtrace)) {
 		threads = 1;
 	} else {
 		threads = libtrace->perpkt_thread_count;
 	}
-	stats->received = 0;
-	stats->dropped = 0;
-	stats->received_valid = 0;
-	stats->dropped_valid = 0;
+
 	for (i = 0; i < threads; i++) {
 		struct pfringzc_per_thread *stream = &(ZC_FORMAT_DATA->perthreads[i]);
-		rc = pfring_zc_stats(stream->device, &zcstats);
-		if (rc == 0) {
-			stats->received += zcstats.recv;
-			stats->dropped += zcstats.drop;
-			stats->received_valid = 1;
-			stats->dropped_valid = 1;
-		} else {
-			stats->received_valid = 0;
-			stats->dropped_valid = 0;
-			return;
-		}
+		if (pfring_zc_stats(stream->device, &zcstats) != 0) {
+                        trace_set_err(libtrace, errno, "Failed to get statistics for pfring stream %u", (uint32_t)i);
+                        continue;
+                }
+
+                stats->dropped += zcstats.drop;
 	}
+
+        if (ZC_FORMAT_DATA->interface_stats.if_name[0] != 0) {
+                if (linux_get_dev_statistics(pfring_ifname_from_uridata(libtrace->uridata),
+                                             &dev_stats) == 0) {
+
+                        // add card drops
+                        stats->dropped += (dev_stats.rx_drops - ZC_FORMAT_DATA->interface_stats.rx_drops);
+                        stats->dropped_valid = 1;
+
+                        // calculate recieved packets by the card, this includes dropped packets but not errored
+                        stats->received = (dev_stats.rx_packets - ZC_FORMAT_DATA->interface_stats.rx_packets);
+                        stats->received += (dev_stats.rx_drops - ZC_FORMAT_DATA->interface_stats.rx_drops);
+                        stats->received_valid = 1;
+
+                        // add card errors
+                        stats->errors = (dev_stats.rx_errors - ZC_FORMAT_DATA->interface_stats.rx_errors);
+                        stats->errors_valid = 1;
+                }
+        }
+
+        if (stats->received_valid && stats->dropped_valid) {
+               stats->captured = stats->received - stats->dropped;
+               stats->captured_valid = 1;
+        }
 }
 
 static void pfringzc_get_thread_stats(UNUSED libtrace_t *libtrace,
@@ -1335,10 +1357,10 @@ static int pfringzc_pregister_thread(libtrace_t *libtrace,
 	return 0;
 }
 
-static struct libtrace_format_t pfringformat = {
-	"pfring",
+static struct libtrace_format_t pfringoldformat = {
+	"pfringold",
 	"$Id$",
-	TRACE_FORMAT_PFRING,
+	TRACE_FORMAT_PFRINGOLD,
 	NULL,                           /* probe filename */
         NULL,                           /* probe magic */
         pfring_init_input,              /* init_input */
@@ -1390,10 +1412,10 @@ static struct libtrace_format_t pfringformat = {
 
 };
 
-static struct libtrace_format_t pfringzcformat = {
-        "pfringzc",
+static struct libtrace_format_t pfringformat = {
+        "pfring",
         "$Id$",
-        TRACE_FORMAT_PFRINGZC,
+        TRACE_FORMAT_PFRING,
         NULL,                           /* probe filename */
         NULL,                           /* probe magic */
         pfringzc_init_input,            /* init_input */
@@ -1444,10 +1466,10 @@ static struct libtrace_format_t pfringzcformat = {
 	pfringzc_get_thread_stats       /* get thread stats */
 };
 
-void pfring_constructor(void) {
-	register_format(&pfringformat);
+void pfringold_constructor(void) {
+	register_format(&pfringoldformat);
 }
 
-void pfringzc_constructor(void) {
-        register_format(&pfringzcformat);
+void pfring_constructor(void) {
+        register_format(&pfringformat);
 }

--- a/lib/format_pfring.c
+++ b/lib/format_pfring.c
@@ -86,6 +86,7 @@ struct pfringzc_format_data_t {
 	char *bpffilter;
 	enum hasher_types hashtype;
 	struct linux_dev_stats interface_stats;
+	bool zero_copy;
 };
 
 struct pfring_per_stream_t {
@@ -96,7 +97,6 @@ struct pfring_per_stream_t {
 #define ZERO_STATS(x) {\
         x->dropped = 0; x->dropped_valid = 0;\
         x->received = 0; x->received_valid = 0;\
-        x->errors = 0; x->errors_valid = 0;\
         x->captured = 0; x->captured_valid = 0;\
 }
 
@@ -210,6 +210,10 @@ static inline char *pfring_ifname_from_uridata(char *uridata) {
                 interface = uridata;
         }
         return interface;
+}
+
+static inline bool pfring_ifname_is_zc(char *uridata) {
+	return (strstr(uridata, "zc:") != NULL);
 }
 
 static inline uint64_t pfring_timespec_to_systime(pfring_zc_timespec *ts) {
@@ -333,13 +337,15 @@ static int pfringzc_max_packet_length(char *device) {
 static int pfringzc_configure_interface(char *uridata,
                                         int threads,
                                         bool dedicated_hasher,
-                                        struct linux_dev_stats *stats,
+                                        struct pfringzc_format_data_t *fdata,
                                         char *err,
                                         int errlen) {
 	char *interface = pfring_ifname_from_uridata(uridata);
 	if (threads == 0 || dedicated_hasher) {
 		threads = 1;
         }
+	// check if ZC is used
+	fdata->zero_copy = pfring_ifname_is_zc(uridata);
 	// check interface exists
 	if (if_nametoindex(interface) == 0) {
                 snprintf(err, errlen, "Invalid interface name: %s", interface);
@@ -355,11 +361,10 @@ static int pfringzc_configure_interface(char *uridata,
                         //return -1;
 		}
 	}
-        // get initial interface statistics
-        if (linux_get_dev_statistics(interface, stats) != 0) {
-                stats->if_name[0] = 0;
+        // get initial interface statistics (this only actually works when not doing ZC)
+        if (linux_get_dev_statistics(interface, &(fdata->interface_stats)) != 0) {
+                fdata->interface_stats.if_name[0] = 0;
         }
-
         return threads;
 }
 
@@ -374,7 +379,7 @@ static int pfringzc_start_input(libtrace_t *libtrace) {
         if ((threads = pfringzc_configure_interface(libtrace->uridata,
                                                     libtrace->perpkt_thread_count,
                                                     trace_has_dedicated_hasher(libtrace),
-                                                    &(ZC_FORMAT_DATA->interface_stats),
+                                                    ZC_FORMAT_DATA,
                                                     err,
                                                     sizeof(err))) == -1) {
                 trace_set_err(libtrace, errno, "%s", err);
@@ -409,7 +414,7 @@ static int pfringzc_start_output(libtrace_out_t *libtrace) {
         if ((threads = pfringzc_configure_interface(libtrace->uridata,
                                                     1,
                                                     0,
-                                                    &(ZC_FORMAT_DATA->interface_stats),
+                                                    ZC_FORMAT_DATA,
                                                     err,
                                                     sizeof(err))) == -1) {
                 trace_set_err_out(libtrace, errno, "%s", err);
@@ -580,13 +585,16 @@ static int pfringzc_init_input(libtrace_t *libtrace) {
 	ZC_FORMAT_DATA->hashtype = HASHER_BIDIRECTIONAL;
 	ZC_FORMAT_DATA->clusterid = (uint16_t)rand();
 	ZC_FORMAT_DATA->perthreads = NULL;
+	ZC_FORMAT_DATA->zero_copy = 0;
 
 	return 0;
 }
 
 static int pfringzc_init_output(libtrace_out_t *libtrace) {
+
         libtrace->format_data = (struct pfringzc_format_data_t *)
                 malloc(sizeof(struct pfringzc_format_data_t));
+
         ZC_FORMAT_DATA->cluster = NULL;
         ZC_FORMAT_DATA->devices = NULL;
         ZC_FORMAT_DATA->clusterid = (uint16_t)rand();
@@ -595,6 +603,8 @@ static int pfringzc_init_output(libtrace_out_t *libtrace) {
         ZC_FORMAT_DATA->snaplen = LIBTRACE_PACKET_BUFSIZE;
         ZC_FORMAT_DATA->bpffilter = NULL;
         ZC_FORMAT_DATA->hashtype = HASHER_BIDIRECTIONAL;
+	ZC_FORMAT_DATA->zero_copy = 0;
+
         return 0;
 }
 
@@ -1276,7 +1286,7 @@ static void pfringzc_get_stats(libtrace_t *libtrace,
 			       libtrace_stat_t *stats) {
 	int threads, i;
 	pfring_zc_stat zcstats;
-        struct linux_dev_stats dev_stats;
+	struct linux_dev_stats dev_stats;
         ZERO_STATS(stats);
 
 	if (libtrace->perpkt_thread_count == 0 || trace_has_dedicated_hasher(libtrace)) {
@@ -1286,59 +1296,99 @@ static void pfringzc_get_stats(libtrace_t *libtrace,
 	}
 
 	for (i = 0; i < threads; i++) {
-		struct pfringzc_per_thread *stream = &(ZC_FORMAT_DATA->perthreads[i]);
-		if (pfring_zc_stats(stream->device, &zcstats) != 0) {
-                        trace_set_err(libtrace, errno, "Failed to get statistics for pfring stream %u", (uint32_t)i);
-                        continue;
+                struct pfringzc_per_thread *stream = &(ZC_FORMAT_DATA->perthreads[i]);
+                if (pfring_zc_stats(stream->device, &zcstats) != 0) {
+                        trace_set_err(libtrace, errno, "Failed to get statistics for pfring\n");
+                        return;
                 }
+
+		// libtrace received includes dropped
+	        stats->received += zcstats.recv + zcstats.drop;
+	        stats->received_valid = 1;
 
                 stats->dropped += zcstats.drop;
-	}
-
-        if (ZC_FORMAT_DATA->interface_stats.if_name[0] != 0) {
-                if (linux_get_dev_statistics(pfring_ifname_from_uridata(libtrace->uridata),
-                                             &dev_stats) == 0) {
-
-                        // add card drops
-                        stats->dropped += (dev_stats.rx_drops - ZC_FORMAT_DATA->interface_stats.rx_drops);
-                        stats->dropped_valid = 1;
-
-                        // calculate recieved packets by the card, this includes dropped packets but not errored
-                        stats->received = (dev_stats.rx_packets - ZC_FORMAT_DATA->interface_stats.rx_packets);
-                        stats->received += (dev_stats.rx_drops - ZC_FORMAT_DATA->interface_stats.rx_drops);
-                        stats->received_valid = 1;
-
-                        // add card errors
-                        stats->errors = (dev_stats.rx_errors - ZC_FORMAT_DATA->interface_stats.rx_errors);
-                        stats->errors_valid = 1;
-                }
+                stats->dropped_valid = 1;
         }
 
-        if (stats->received_valid && stats->dropped_valid) {
-               stats->captured = stats->received - stats->dropped;
-               stats->captured_valid = 1;
+	// when using zero copy stats from pfring_zc_stats are correct however when not in zero copy we
+	// need to get stats from the card
+	if (!(ZC_FORMAT_DATA->zero_copy)) {
+		if (ZC_FORMAT_DATA->interface_stats.if_name[0] != 0) {
+                	if (linux_get_dev_statistics(pfring_ifname_from_uridata(libtrace->uridata),
+                                                     &dev_stats) == 0) {
+
+                        	// add card drops
+                        	stats->dropped += (dev_stats.rx_drops - ZC_FORMAT_DATA->interface_stats.rx_drops);
+                        	stats->dropped_valid = 1;
+
+                        	// calculate recieved packets by the card, this includes dropped packets but not errored
+                        	stats->received = (dev_stats.rx_packets - ZC_FORMAT_DATA->interface_stats.rx_packets);
+                        	stats->received += (dev_stats.rx_drops - ZC_FORMAT_DATA->interface_stats.rx_drops);
+                        	stats->received_valid = 1;
+
+                        	// add card errors
+                        	stats->errors = (dev_stats.rx_errors - ZC_FORMAT_DATA->interface_stats.rx_errors);
+                        	stats->errors_valid = 1;
+			}
+        	}
+	}
+
+	if (stats->received_valid && stats->dropped_valid) {
+                stats->captured = stats->received - stats->dropped;
+        	stats->captured_valid = 1;
         }
 }
 
-static void pfringzc_get_thread_stats(UNUSED libtrace_t *libtrace,
+static void pfringzc_get_thread_stats(libtrace_t *libtrace,
 				      libtrace_thread_t *thread,
 				      libtrace_stat_t *stats) {
-	int rc;
 	pfring_zc_stat zcstats;
-	struct pfringzc_per_thread *stream = (struct pfringzc_per_thread *)thread->format_data;
-	stats->received = 0;
-	stats->dropped = 0;
-	stats->received_valid = 0;
-	stats->dropped_valid = 0;
+	struct linux_dev_stats dev_stats;
+	ZERO_STATS(stats);
+	struct pfringzc_per_thread *stream;
+
+	stream = (struct pfringzc_per_thread *)thread->format_data;
 	if (stream != NULL) {
-		rc = pfring_zc_stats(stream->device, &zcstats);
-		if (rc == 0) {
-			stats->received += zcstats.recv;
-			stats->dropped += zcstats.drop;
-			stats->received_valid = 1;
-			stats->dropped_valid = 1;
+		if (pfring_zc_stats(stream->device, &zcstats) != 0) {
+			trace_set_err(libtrace, errno, "Failed to get pfring thread statistics\n");
+			return;
 		}
+
+		// libtrace received includes dropped
+                stats->received += zcstats.recv + zcstats.drop;
+                stats->received_valid = 1;
+
+                stats->dropped += zcstats.drop;
+                stats->dropped_valid = 1;
 	}
+
+	// when using zero copy stats from pfring_zc_stats are correct however when not in zero copy we
+        // need to get stats from the card
+        if (!(ZC_FORMAT_DATA->zero_copy)) {
+                if (ZC_FORMAT_DATA->interface_stats.if_name[0] != 0) {
+                        if (linux_get_dev_statistics(pfring_ifname_from_uridata(libtrace->uridata),
+                                                     &dev_stats) == 0) {
+
+                                // add card drops
+                                stats->dropped += (dev_stats.rx_drops - ZC_FORMAT_DATA->interface_stats.rx_drops);
+                                stats->dropped_valid = 1;
+
+                                // calculate recieved packets by the card, this includes dropped packets but not errored
+                                stats->received = (dev_stats.rx_packets - ZC_FORMAT_DATA->interface_stats.rx_packets);
+                                stats->received += (dev_stats.rx_drops - ZC_FORMAT_DATA->interface_stats.rx_drops);
+                                stats->received_valid = 1;
+
+                                // add card errors
+                                stats->errors = (dev_stats.rx_errors - ZC_FORMAT_DATA->interface_stats.rx_errors);
+                                stats->errors_valid = 1;
+                        }
+                }
+        }
+
+	if (stats->received_valid && stats->dropped_valid) {
+               stats->captured = stats->received - stats->dropped;
+               stats->captured_valid = 1;
+        }
 }
 
 static int pfringzc_pregister_thread(libtrace_t *libtrace,

--- a/lib/libtrace.h.in
+++ b/lib/libtrace.h.in
@@ -461,8 +461,8 @@ enum base_format_t {
 	TRACE_FORMAT_TZSPLIVE	  =23,  /** TZSP */
         TRACE_FORMAT_CORSAROTAG   =24,  /** Corsarotagger format */
         TRACE_FORMAT_XDP          =25,  /** AF_XDP format */
-	TRACE_FORMAT_PFRING	  =26,
-	TRACE_FORMAT_PFRINGZC     =27,
+	TRACE_FORMAT_PFRINGOLD	  =26,
+	TRACE_FORMAT_PFRING       =27,
 };
 
 /** RT protocol packet types */
@@ -528,8 +528,8 @@ typedef enum {
         TRACE_RT_DATA_XDP = TRACE_RT_DATA_SIMPLE + TRACE_FORMAT_XDP,
 
 	/** RT is encapsulating a PF_RING capture record */
+	TRACE_RT_DATA_PFRINGOLD = TRACE_RT_DATA_SIMPLE + TRACE_FORMAT_PFRINGOLD,
 	TRACE_RT_DATA_PFRING = TRACE_RT_DATA_SIMPLE + TRACE_FORMAT_PFRING,
-	TRACE_RT_DATA_PFRINGZC = TRACE_RT_DATA_SIMPLE + TRACE_FORMAT_PFRING,
 
 	/** As PCAP does not store the linktype with the packet, we need to 
 	 * create a separate RT type for each supported DLT, starting from

--- a/lib/libtrace_int.h
+++ b/lib/libtrace_int.h
@@ -1395,8 +1395,8 @@ void dpdkndag_constructor(void);
 void linux_xdp_constructor(void);
 #endif
 #if HAVE_PFRING
+void pfringold_constructor(void);
 void pfring_constructor(void);
-void pfringzc_constructor(void);
 #endif
 
 /** Extracts the RadioTap flags from a wireless link header

--- a/lib/trace.c
+++ b/lib/trace.c
@@ -170,8 +170,8 @@ static void trace_init(void)
                 linux_xdp_constructor();
 #endif
 #ifdef HAVE_PFRING
+                pfringold_constructor();
                 pfring_constructor();
-                pfringzc_constructor();
 #endif
 	}
 }


### PR DESCRIPTION
This makes the PF_RING ZC api the default format when using pfring, the non ZC api now uses the uri pfringold
Fixes statistic counters for the ZC and non ZC api.
Moves linuxcommon_get_dev_statistics from linux_common to linux_helps as PF_RING has duplicate definitions including linux_common.
