### PR TITLE
Fix: Valgrind trace_pstop() hanging

### DIFF
--- a/lib/data-struct/message_queue.h
+++ b/lib/data-struct/message_queue.h
@@ -50,5 +50,7 @@ DLLEXPORT int libtrace_message_queue_try_get(libtrace_message_queue_t *mq,
         void *message);
 DLLEXPORT void libtrace_message_queue_destroy(libtrace_message_queue_t *mq);
 DLLEXPORT int libtrace_message_queue_get_fd(libtrace_message_queue_t *mq);
+DLLEXPORT int libtrace_message_queue_select(libtrace_message_queue_t *mq,
+                                            struct timeval *timeout);
 
 #endif


### PR DESCRIPTION
Fix for extended hangs when calling `trace_pstop()` or `trace_ppause()` when running under valgrind.

Details in the commit message.