### PR TITLE
Tidy GitHub actions

### DIFF
--- a/.github/workflows/dag.yaml
+++ b/.github/workflows/dag.yaml
@@ -5,6 +5,7 @@ on:
 jobs:
   pre_job:
     name: Prerequisite checks
+    if: ${{ github.repository_owner == 'LibtraceTeam' }}
     runs-on: ubuntu-latest
     outputs:
       should_skip: ${{ steps.skip_check.outputs.should_skip }}

--- a/.github/workflows/dag.yaml
+++ b/.github/workflows/dag.yaml
@@ -51,7 +51,7 @@ jobs:
     - name: Build DAG kernel module
       run: |
         cd dag-packages/kernel-module
-        sudo make KSRC=/lib/modules/$(uname -r)/build
+        sudo make -j 3  KSRC=/lib/modules/$(uname -r)/build
         sudo make install KSRC=/lib/modules/$(uname -r)/build
     - name: Install DAG packages
       run: |
@@ -73,7 +73,7 @@ jobs:
         cd libtrace/wandio
         ./bootstrap.sh
         ./configure
-        make
+        make -j 3
         sudo make install
         sudo ldconfig
     - name: Build/Install Libtrace
@@ -81,10 +81,10 @@ jobs:
         cd libtrace
         ./bootstrap.sh
         ./configure CFLAGS="-I$(pwd)/../libbpf/include/uapi" --with-dag
-        make
+        make -j 3
         sudo make install
     - name: Build Tests
-      run: cd libtrace/test; make
+      run: cd libtrace/test; make -j 3
     - name: Run do-tests.sh
       run: cd libtrace/test; ./do-tests.sh
     - name: Run do-tests-parallel.sh

--- a/.github/workflows/dag.yaml
+++ b/.github/workflows/dag.yaml
@@ -21,6 +21,7 @@ jobs:
     if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-20.04, ubuntu-18.04]
         c_compiler: [gcc, clang]

--- a/.github/workflows/dpdk.yaml
+++ b/.github/workflows/dpdk.yaml
@@ -31,6 +31,7 @@ jobs:
     if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-20.04]
         dpdk_version: [dpdk-20.11, dpdk-20.02, dpdk-19.11.5, dpdk-18.11.10, dpdk-17.11.10, dpdk-16.11.11]

--- a/.github/workflows/dpdk.yaml
+++ b/.github/workflows/dpdk.yaml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, ubuntu-18.04, ubuntu-16.04]
+        os: [ubuntu-20.04]
         dpdk_version: [dpdk-20.11, dpdk-20.02, dpdk-19.11.5, dpdk-18.11.10, dpdk-17.11.10, dpdk-16.11.11]
         exclude:
           - os: ubuntu-16.04

--- a/.github/workflows/dpdk.yaml
+++ b/.github/workflows/dpdk.yaml
@@ -63,7 +63,7 @@ jobs:
         cd libtrace/wandio
         ./bootstrap.sh
         ./configure
-        make
+        make -j 3
         sudo make install
         sudo ldconfig
     - name: Build ${{ matrix.dpdk_version }}

--- a/.github/workflows/libtrace.yaml
+++ b/.github/workflows/libtrace.yaml
@@ -50,7 +50,7 @@ jobs:
       run: |
         sudo apt update
         sudo apt-get -y install flex bison libpcap0.8-dev libtool pkgconf autoconf automake m4 gcc clang llvm gcc-multilib
-        sudo apt-get -y install build-essential dpdk-dev libelf-dev git
+        sudo apt-get -y install build-essential dpdk-dev libelf-dev git libyaml-dev libssl-dev
     - name: Install PF_RING
       run: |
         sudo apt-get -y install software-properties-common wget
@@ -80,6 +80,14 @@ jobs:
     - name: Build/Install Wandio
       run: |
         cd libtrace/wandio
+        ./bootstrap.sh
+        ./configure
+        make
+        sudo make install
+        sudo ldconfig
+    - name: Build/Install Libwandder
+      run: |
+        cd libtrace/libwandder
         ./bootstrap.sh
         ./configure
         make

--- a/.github/workflows/libtrace.yaml
+++ b/.github/workflows/libtrace.yaml
@@ -21,6 +21,7 @@ jobs:
     if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-20.04, ubuntu-18.04]
         c_compiler: [gcc, clang]
@@ -31,7 +32,7 @@ jobs:
           - c_compiler: clang
             cxx_compiler: g++
     steps:
-    - name: Setup Enviroment Variables
+    - name: Setup Environment Variables
       env:
         CC: ${{ matrix.c_compiler }}
         CXX: ${{ matrix.cxx_compiler }}
@@ -107,6 +108,7 @@ jobs:
     if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [macos-10.15]
     steps:

--- a/.github/workflows/libtrace.yaml
+++ b/.github/workflows/libtrace.yaml
@@ -68,7 +68,7 @@ jobs:
     - name: Build/Install Libbpf
       run: |
         cd libbpf/src
-        make
+        make -j 3
         sudo make install
         echo "/usr/lib64" | sudo tee -a /etc/ld.so.conf.d/lib64.conf
         sudo ldconfig
@@ -82,7 +82,7 @@ jobs:
         cd libtrace/wandio
         ./bootstrap.sh
         ./configure
-        make
+        make -j 3
         sudo make install
         sudo ldconfig
     - name: Build/Install Libwandder
@@ -90,7 +90,7 @@ jobs:
         cd libtrace/libwandder
         ./bootstrap.sh
         ./configure
-        make
+        make -j 3
         sudo make install
         sudo ldconfig
     - name: Build/Install Libtrace
@@ -98,10 +98,10 @@ jobs:
         cd libtrace
         ./bootstrap.sh
         ./configure CFLAGS="-I$(pwd)/../libbpf/include/uapi" --with-dpdk --with-pfring --with-xdp
-        make
+        make -j 3
         sudo make install
     - name: Build Tests
-      run: cd libtrace/test; make
+      run: cd libtrace/test; make -j 3
     - name: Run do-tests.sh
       run: cd libtrace/test; ./do-tests.sh
     - name: Run do-tests-parallel.sh
@@ -131,16 +131,16 @@ jobs:
         cd wandio
         ./bootstrap.sh
         ./configure
-        make
+        make -j 4
         sudo make install
     - name: Build/Install Libtrace
       run: |
         ./bootstrap.sh
         ./configure
-        make
+        make -j 4
         sudo make install
     - name: Build Tests
-      run: cd test; make
+      run: cd test; make -j 4
     - name: Run do-tests.sh
       run: cd test; ./do-tests.sh
     - name: Run do-tests-parallel.sh

--- a/test/do-live-tests.sh
+++ b/test/do-live-tests.sh
@@ -144,7 +144,6 @@ do_parallel_test() {
 		PARALLEL_FAIL="$PARALLEL_FAIL
 $*"
 	fi
-	sleep 2
 }
 
 for r in "${read_formats[@]}"
@@ -154,12 +153,12 @@ do
 	if [[ $r == "pcapint:veth1" ]]; then
 		continue
 	fi
-	do_parallel_test ./test-format-parallel "$r" "int:veth1"
-	do_parallel_test ./test-format-parallel-hasher "$r" "int:veth1"
+	do_parallel_test ./test-format-parallel "$r" "int:veth0"
+	do_parallel_test ./test-format-parallel-hasher "$r" "int:veth0"
 	# TODO fix test-format-parallel-reporter for live input
-	# do_parallel_test ./test-format-parallel-reporter "$r" "int:veth1"
-	do_parallel_test ./test-format-parallel-singlethreaded "$r" "int:veth1"
-	do_parallel_test ./test-format-parallel-singlethreaded-hasher "$r" "int:veth1"
+	# do_parallel_test ./test-format-parallel-reporter "$r" "int:veth0"
+	do_parallel_test ./test-format-parallel-singlethreaded "$r" "int:veth0"
+	do_parallel_test ./test-format-parallel-singlethreaded-hasher "$r" "int:veth0"
 
 done
 


### PR DESCRIPTION
 - Only run DAG tests against the main repo
 - Use threads (-j) with make
 - Only run DPDK tests against Ubuntu 20.04, not much point duplicating for each Ubuntu version
 - Enable more features in the build, traceanon and libwanddr libs
 - Let tests run to completion if they fail on one distro
 - Fixes a bug in do-live-tests