### PR TITLE
DPDK: reset port stats after starting the port

### DIFF
--- a/lib/format_dpdk.c
+++ b/lib/format_dpdk.c
@@ -1775,8 +1775,7 @@ static int dpdk_start_streams(struct dpdk_format_data_t *format_data, char *err,
         ret = 0;
 #endif
         if (ret != 0) {
-                fprintf(
-                        stderr,
+                fprintf(stderr,
                         "Libtrace DPDK: rte_eth_stats_reset failed %d : %s\n",
                         ret, strerror(-ret));
         }

--- a/lib/format_dpdk.c
+++ b/lib/format_dpdk.c
@@ -1758,7 +1758,6 @@ static int dpdk_start_streams(struct dpdk_format_data_t *format_data, char *err,
 #if DEBUG
         fprintf(stderr, "Libtrace DPDK: Doing start device\n");
 #endif
-        rte_eth_stats_reset(format_data->port);
         /* Start device */
         ret = rte_eth_dev_start(format_data->port);
         if (ret < 0) {
@@ -1766,6 +1765,20 @@ static int dpdk_start_streams(struct dpdk_format_data_t *format_data, char *err,
                          "Libtrace DPDK: rte_eth_dev_start failed : %s",
                          strerror(-ret));
                 return -1;
+        }
+
+#if RTE_VERSION >= RTE_VERSION_NUM(17, 11, 0, 1)
+        /* from 17.11-rc1 this returns a value */
+        ret = rte_eth_stats_reset(format_data->port);
+#else
+        rte_eth_stats_reset(format_data->port);
+        ret = 0;
+#endif
+        if (ret != 0) {
+                fprintf(
+                        stderr,
+                        "Libtrace DPDK: rte_eth_stats_reset failed %d : %s\n",
+                        ret, strerror(-ret));
         }
 
         /* Default promiscuous to on */


### PR DESCRIPTION
Napatech's DPDK driver throws an error if port stats are reset
before the port is started.

Doing this before vs. after starting the port is pretty much identical.
As it is not an atomic operation performed alongside starting the port, it
can result in a little bit of error in either case.