### PR TITLE
Fixes for the `etsilive:` format

### DIFF
--- a/lib/data-struct/simple_circular_buffer.c
+++ b/lib/data-struct/simple_circular_buffer.c
@@ -106,8 +106,8 @@ DLLEXPORT int libtrace_scb_recv_sock(libtrace_scb_t *buf, int sock,
                 return -1;
         }
 
-        if (space == 0) {
-                return buf->count_bytes;
+        if (space < 512 * 1024) {
+                return buf->count_bytes - space;
         }
 
         ret = recv(sock, buf->address + buf->write_offset, space, recvflags);

--- a/lib/data-struct/simple_circular_buffer.c
+++ b/lib/data-struct/simple_circular_buffer.c
@@ -81,6 +81,20 @@ DLLEXPORT void libtrace_scb_destroy(libtrace_scb_t *buf) {
 
 }
 
+DLLEXPORT int libtrace_scb_get_available_space(libtrace_scb_t *buf) {
+        if (buf->address == NULL) {
+                return 0;
+        }
+        return buf->count_bytes - (buf->write_offset - buf->read_offset);
+}
+
+DLLEXPORT int libtrace_scb_get_size(libtrace_scb_t *buf) {
+        if (buf->address == NULL) {
+                return 0;
+        }
+        return buf->count_bytes;
+}
+
 DLLEXPORT int libtrace_scb_recv_sock(libtrace_scb_t *buf, int sock,
                 int recvflags) {
         int space = buf->count_bytes - (buf->write_offset - buf->read_offset);

--- a/lib/data-struct/simple_circular_buffer.c
+++ b/lib/data-struct/simple_circular_buffer.c
@@ -81,14 +81,16 @@ DLLEXPORT void libtrace_scb_destroy(libtrace_scb_t *buf) {
 
 }
 
-DLLEXPORT int libtrace_scb_get_available_space(libtrace_scb_t *buf) {
+DLLEXPORT int libtrace_scb_get_available_space(libtrace_scb_t *buf)
+{
         if (buf->address == NULL) {
                 return 0;
         }
         return buf->count_bytes - (buf->write_offset - buf->read_offset);
 }
 
-DLLEXPORT int libtrace_scb_get_size(libtrace_scb_t *buf) {
+DLLEXPORT int libtrace_scb_get_size(libtrace_scb_t *buf)
+{
         if (buf->address == NULL) {
                 return 0;
         }

--- a/lib/data-struct/simple_circular_buffer.h
+++ b/lib/data-struct/simple_circular_buffer.h
@@ -21,5 +21,6 @@ DLLEXPORT int libtrace_scb_recv_sock(libtrace_scb_t *buf, int sock,
 DLLEXPORT uint8_t *libtrace_scb_get_read(libtrace_scb_t *buf,
                 uint32_t *available);
 DLLEXPORT void libtrace_scb_advance_read(libtrace_scb_t *buf, uint32_t forward);
-
+DLLEXPORT int libtrace_scb_get_available_space(libtrace_scb_t *buf);
+DLLEXPORT int libtrace_scb_get_size(libtrace_scb_t *buf);
 #endif

--- a/lib/format_etsilive.c
+++ b/lib/format_etsilive.c
@@ -39,7 +39,6 @@
 #include <libwandder_etsili.h>
 
 #include <errno.h>
-#include <assert.h>
 #include <fcntl.h>
 #include <stdio.h>
 #include <string.h>
@@ -504,8 +503,6 @@ static inline void inspect_next_packet(etsisocket_t *sock,
                 }
         }
 
-        /* Quick sanity check while I'm still debugging this code */
-        assert(reclen <= 10000);
         if (available < reclen) {
                 /* Don't have the whole PDU yet */
                 return;
@@ -537,8 +534,6 @@ static inline void inspect_next_packet(etsisocket_t *sock,
 
         tv = wandder_etsili_get_header_timestamp(dec);
         if (tv.tv_sec == 0) {
-                /* TODO this is just for debugging -- remove later */
-                assert(tv.tv_sec != 0);
                 return;
         }
         current = ((((uint64_t)tv.tv_sec) << 32) +

--- a/lib/format_etsilive.c
+++ b/lib/format_etsilive.c
@@ -79,8 +79,8 @@ typedef struct etsithread {
 } etsithread_t;
 
 typedef struct etsilive_format_data {
-	char *listenport;
-	char *listenaddr;
+        char *listenport;
+        char *listenaddr;
 
         pthread_t listenthread;
         etsithread_t *receivers;
@@ -187,8 +187,8 @@ static void *etsi_listener(void *tdata) {
 
                 if (FORMAT_DATA->maxthreads > 1) {
                         FORMAT_DATA->nextthreadid =
-                                ((FORMAT_DATA->nextthreadid + 1) %
-                                FORMAT_DATA->maxthreads);
+                            ((FORMAT_DATA->nextthreadid + 1) %
+                              FORMAT_DATA->maxthreads);
                 }
         }
 
@@ -218,11 +218,11 @@ static int etsilive_init_input(libtrace_t *libtrace) {
         libtrace->format_data = (etsilive_format_data_t *)malloc(
                         sizeof(etsilive_format_data_t));
 
-	if (!libtrace->format) {
-		trace_set_err(libtrace, TRACE_ERR_INIT_FAILED, "Unable to allocate memory for "
-			"format data inside etsilive_init_input()");
-		return 1;
-	}
+        if (!libtrace->format) {
+                trace_set_err(libtrace, TRACE_ERR_INIT_FAILED, "Unable to allocate memory for "
+                        "format data inside etsilive_init_input()");
+                return 1;
+        }
 
         FORMAT_DATA->receivers = NULL;
         FORMAT_DATA->nextthreadid = 0;
@@ -265,7 +265,7 @@ static int etsilive_fin_input(libtrace_t *libtrace) {
 }
 
 static int etsilive_start_threads(libtrace_t *libtrace, uint32_t maxthreads) {
-	int ret;
+        int ret;
         uint32_t i;
         /* Configure the set of receiver threads */
 
@@ -652,10 +652,10 @@ static int etsilive_get_pdu_length(const libtrace_packet_t *packet) {
         libtrace_t *libtrace = packet->trace;
         wandder_etsispec_t *dec;
 
-	if (!libtrace) {
-		fprintf(stderr, "Packet is not associated with a trace in etsilive_get_pdu_length()\n");
-		return TRACE_ERR_NULL_TRACE;
-	}
+        if (!libtrace) {
+                fprintf(stderr, "Packet is not associated with a trace in etsilive_get_pdu_length()\n");
+                return TRACE_ERR_NULL_TRACE;
+        }
         /* Creating a decoder every time will be slow, but again we
          * should never get here anyway...
          */
@@ -679,7 +679,8 @@ static uint64_t etsilive_get_erf_timestamp(const libtrace_packet_t *packet) {
         return packet->order;
 }
 
-static int etsilive_can_hold_packet(libtrace_packet_t *packet) {
+static int etsilive_can_hold_packet(libtrace_packet_t *packet)
+{
         int wlen = -1;
 
         /* Can hold the packet (temporarily) as long as a decent chunk of
@@ -689,7 +690,7 @@ static int etsilive_can_hold_packet(libtrace_packet_t *packet) {
         if (!is_halted && packet->fmtdata != NULL) {
                 libtrace_scb_t *scb = (libtrace_scb_t *)packet->fmtdata;
                 if (libtrace_scb_get_available_space(scb) >
-                                0.25 * ETSI_RECVBUF_SIZE) {
+                    0.25 * ETSI_RECVBUF_SIZE) {
                         return 0;
                 }
         }
@@ -714,52 +715,51 @@ static libtrace_linktype_t etsilive_get_link_type(
 }
 
 static struct libtrace_format_t etsilive = {
-        "etsilive",
-        "$Id$",
-        TRACE_FORMAT_ETSILIVE,
-        NULL,                           /* probe filename */
-        NULL,                           /* probe magic */
-        etsilive_init_input,            /* init_input */
-        NULL,                           /* config_input */
-        etsilive_start_input,           /* start_input */
-        etsilive_pause_input,           /* pause */
-        NULL,                           /* init_output */
-        NULL,                           /* config_output */
-        NULL,                           /* start_output */
-        etsilive_fin_input,             /* fin_input */
-        NULL,                           /* fin_output */
-        etsilive_read_packet,           /* read_packet */
-        etsilive_prepare_packet,        /* prepare_packet */
-        NULL,                           /* fin_packet */
-        etsilive_can_hold_packet,       /* can_hold_packet */
-        NULL,                           /* write_packet */
-        NULL,                           /* flush_output */
-        etsilive_get_link_type,         /* get_link_type */
-        NULL,                           /* get_direction */
-        NULL,                           /* set_direction */
-        etsilive_get_erf_timestamp,     /* get_erf_timestamp */
-        NULL,                           /* get_timeval */
-        NULL,                           /* get_timespec */
-        NULL,                           /* get_seconds */
-	NULL,                           /* get_meta_section */
-        NULL,                           /* seek_erf */
-        NULL,                           /* seek_timeval */
-        NULL,                           /* seek_seconds */
-        etsilive_get_pdu_length,        /* get_capture_length */
-        etsilive_get_pdu_length,        /* get_wire_length */
-        etsilive_get_framing_length,    /* get_framing_length */
-        NULL,                           /* set_capture_length */
-        NULL,                           /* get_received_packets */
-        NULL,                           /* get_filtered_packets */
-        NULL,                           /* get_dropped_packets */
-        NULL,                           /* get_statistics */
-        NULL,                           /* get_fd */
-        NULL, //trace_event_etsilive,           /* trace_event */
-        NULL,                           /* help */
-        NULL,                           /* next pointer */
-        NON_PARALLEL(true)              /* TODO this can be parallel */
+    "etsilive",
+    "$Id$",
+    TRACE_FORMAT_ETSILIVE,
+    NULL,                           /* probe filename */
+    NULL,                           /* probe magic */
+    etsilive_init_input,            /* init_input */
+    NULL,                           /* config_input */
+    etsilive_start_input,           /* start_input */
+    etsilive_pause_input,           /* pause */
+    NULL,                           /* init_output */
+    NULL,                           /* config_output */
+    NULL,                           /* start_output */
+    etsilive_fin_input,             /* fin_input */
+    NULL,                           /* fin_output */
+    etsilive_read_packet,           /* read_packet */
+    etsilive_prepare_packet,        /* prepare_packet */
+    NULL,                           /* fin_packet */
+    etsilive_can_hold_packet,       /* can_hold_packet */
+    NULL,                           /* write_packet */
+    NULL,                           /* flush_output */
+    etsilive_get_link_type,         /* get_link_type */
+    NULL,                           /* get_direction */
+    NULL,                           /* set_direction */
+    etsilive_get_erf_timestamp,     /* get_erf_timestamp */
+    NULL,                           /* get_timeval */
+    NULL,                           /* get_timespec */
+    NULL,                           /* get_seconds */
+    NULL,                           /* get_meta_section */
+    NULL,                           /* seek_erf */
+    NULL,                           /* seek_timeval */
+    NULL,                           /* seek_seconds */
+    etsilive_get_pdu_length,        /* get_capture_length */
+    etsilive_get_pdu_length,        /* get_wire_length */
+    etsilive_get_framing_length,    /* get_framing_length */
+    NULL,                           /* set_capture_length */
+    NULL,                           /* get_received_packets */
+    NULL,                           /* get_filtered_packets */
+    NULL,                           /* get_dropped_packets */
+    NULL,                           /* get_statistics */
+    NULL,                           /* get_fd */
+    NULL, //trace_event_etsilive,           /* trace_event */
+    NULL,                           /* help */
+    NULL,                           /* next pointer */
+    NON_PARALLEL(true)              /* TODO this can be parallel */
 };
-
 
 void etsilive_constructor(void) {
         register_format(&etsilive);

--- a/lib/format_etsilive.c
+++ b/lib/format_etsilive.c
@@ -498,7 +498,6 @@ static inline void inspect_next_packet(etsisocket_t *sock,
                 reclen = sock->cached.length;
         } else {
                 reclen = wandder_etsili_get_pdu_length(dec);
-
                 if (reclen == 0) {
                         return;
                 }
@@ -689,7 +688,7 @@ static int etsilive_can_hold_packet(libtrace_packet_t *packet)
          * our SCB is available.
          * SCB is only valid if the trace is not paused / halted...
          */
-        if (!is_halted && packet->fmtdata != NULL) {
+        if (!is_halted(packet->trace) && packet->fmtdata != NULL) {
                 libtrace_scb_t *scb = (libtrace_scb_t *)packet->fmtdata;
                 if (libtrace_scb_get_available_space(scb) >
                     0.25 * ETSI_RECVBUF_SIZE) {

--- a/lib/format_etsilive.c
+++ b/lib/format_etsilive.c
@@ -188,7 +188,7 @@ static void *etsi_listener(void *tdata) {
                 if (FORMAT_DATA->maxthreads > 1) {
                         FORMAT_DATA->nextthreadid =
                             ((FORMAT_DATA->nextthreadid + 1) %
-                              FORMAT_DATA->maxthreads);
+                             FORMAT_DATA->maxthreads);
                 }
         }
 
@@ -219,8 +219,9 @@ static int etsilive_init_input(libtrace_t *libtrace) {
                         sizeof(etsilive_format_data_t));
 
         if (!libtrace->format) {
-                trace_set_err(libtrace, TRACE_ERR_INIT_FAILED, "Unable to allocate memory for "
-                        "format data inside etsilive_init_input()");
+                trace_set_err(libtrace, TRACE_ERR_INIT_FAILED,
+                              "Unable to allocate memory for "
+                              "format data inside etsilive_init_input()");
                 return 1;
         }
 
@@ -653,7 +654,8 @@ static int etsilive_get_pdu_length(const libtrace_packet_t *packet) {
         wandder_etsispec_t *dec;
 
         if (!libtrace) {
-                fprintf(stderr, "Packet is not associated with a trace in etsilive_get_pdu_length()\n");
+                fprintf(stderr, "Packet is not associated with a trace in "
+                                "etsilive_get_pdu_length()\n");
                 return TRACE_ERR_NULL_TRACE;
         }
         /* Creating a decoder every time will be slow, but again we
@@ -718,47 +720,47 @@ static struct libtrace_format_t etsilive = {
     "etsilive",
     "$Id$",
     TRACE_FORMAT_ETSILIVE,
-    NULL,                           /* probe filename */
-    NULL,                           /* probe magic */
-    etsilive_init_input,            /* init_input */
-    NULL,                           /* config_input */
-    etsilive_start_input,           /* start_input */
-    etsilive_pause_input,           /* pause */
-    NULL,                           /* init_output */
-    NULL,                           /* config_output */
-    NULL,                           /* start_output */
-    etsilive_fin_input,             /* fin_input */
-    NULL,                           /* fin_output */
-    etsilive_read_packet,           /* read_packet */
-    etsilive_prepare_packet,        /* prepare_packet */
-    NULL,                           /* fin_packet */
-    etsilive_can_hold_packet,       /* can_hold_packet */
-    NULL,                           /* write_packet */
-    NULL,                           /* flush_output */
-    etsilive_get_link_type,         /* get_link_type */
-    NULL,                           /* get_direction */
-    NULL,                           /* set_direction */
-    etsilive_get_erf_timestamp,     /* get_erf_timestamp */
-    NULL,                           /* get_timeval */
-    NULL,                           /* get_timespec */
-    NULL,                           /* get_seconds */
-    NULL,                           /* get_meta_section */
-    NULL,                           /* seek_erf */
-    NULL,                           /* seek_timeval */
-    NULL,                           /* seek_seconds */
-    etsilive_get_pdu_length,        /* get_capture_length */
-    etsilive_get_pdu_length,        /* get_wire_length */
-    etsilive_get_framing_length,    /* get_framing_length */
-    NULL,                           /* set_capture_length */
-    NULL,                           /* get_received_packets */
-    NULL,                           /* get_filtered_packets */
-    NULL,                           /* get_dropped_packets */
-    NULL,                           /* get_statistics */
-    NULL,                           /* get_fd */
-    NULL, //trace_event_etsilive,           /* trace_event */
-    NULL,                           /* help */
-    NULL,                           /* next pointer */
-    NON_PARALLEL(true)              /* TODO this can be parallel */
+    NULL,                        /* probe filename */
+    NULL,                        /* probe magic */
+    etsilive_init_input,         /* init_input */
+    NULL,                        /* config_input */
+    etsilive_start_input,        /* start_input */
+    etsilive_pause_input,        /* pause */
+    NULL,                        /* init_output */
+    NULL,                        /* config_output */
+    NULL,                        /* start_output */
+    etsilive_fin_input,          /* fin_input */
+    NULL,                        /* fin_output */
+    etsilive_read_packet,        /* read_packet */
+    etsilive_prepare_packet,     /* prepare_packet */
+    NULL,                        /* fin_packet */
+    etsilive_can_hold_packet,    /* can_hold_packet */
+    NULL,                        /* write_packet */
+    NULL,                        /* flush_output */
+    etsilive_get_link_type,      /* get_link_type */
+    NULL,                        /* get_direction */
+    NULL,                        /* set_direction */
+    etsilive_get_erf_timestamp,  /* get_erf_timestamp */
+    NULL,                        /* get_timeval */
+    NULL,                        /* get_timespec */
+    NULL,                        /* get_seconds */
+    NULL,                        /* get_meta_section */
+    NULL,                        /* seek_erf */
+    NULL,                        /* seek_timeval */
+    NULL,                        /* seek_seconds */
+    etsilive_get_pdu_length,     /* get_capture_length */
+    etsilive_get_pdu_length,     /* get_wire_length */
+    etsilive_get_framing_length, /* get_framing_length */
+    NULL,                        /* set_capture_length */
+    NULL,                        /* get_received_packets */
+    NULL,                        /* get_filtered_packets */
+    NULL,                        /* get_dropped_packets */
+    NULL,                        /* get_statistics */
+    NULL,                        /* get_fd */
+    NULL,                        /* trace_event */
+    NULL,                        /* help */
+    NULL,                        /* next pointer */
+    NON_PARALLEL(true)           /* TODO this can be parallel */
 };
 
 void etsilive_constructor(void) {

--- a/lib/libtrace.h.in
+++ b/lib/libtrace.h.in
@@ -724,7 +724,7 @@ typedef struct libtrace_packet_t {
 	int error;                      /**< The error status of pread_packet */
         uint64_t internalid;            /** Internal identifier for the pkt */
         void *srcbucket;                /** Source bucket in trace_rt or stream in XDP */
-
+        void *fmtdata;                  /**< Storage for format-specific data */
         pthread_mutex_t ref_lock;       /**< Lock for reference counter */
         int refcount;                   /**< Reference counter */
         int which_trace_start;          /**< Used to match packet to a started instance of the parent trace */

--- a/lib/trace.c
+++ b/lib/trace.c
@@ -1038,7 +1038,7 @@ DLLEXPORT void trace_destroy_packet(libtrace_packet_t *packet) {
  */
 void trace_fin_packet(libtrace_packet_t *packet) {
 	if (packet)
-	{
+        {
 		if (packet->trace && packet->trace->format->fin_packet) {
 			packet->trace->format->fin_packet(packet);
 		}
@@ -1068,7 +1068,7 @@ void trace_fin_packet(libtrace_packet_t *packet) {
 		packet->order = 0;
                 packet->srcbucket = NULL;
                 packet->fmtdata = NULL;
-	}
+        }
 }
 
 /* Read one packet from the trace into buffer. Note that this function will

--- a/lib/trace.c
+++ b/lib/trace.c
@@ -1067,6 +1067,7 @@ void trace_fin_packet(libtrace_packet_t *packet) {
 		packet->hash = 0;
 		packet->order = 0;
                 packet->srcbucket = NULL;
+                packet->fmtdata = NULL;
 	}
 }
 

--- a/lib/trace.c
+++ b/lib/trace.c
@@ -1037,35 +1037,36 @@ DLLEXPORT void trace_destroy_packet(libtrace_packet_t *packet) {
  * use trace_destroy_packet() for those diabolical purposes.
  */
 void trace_fin_packet(libtrace_packet_t *packet) {
-	if (packet)
-        {
-		if (packet->trace && packet->trace->format->fin_packet) {
-			packet->trace->format->fin_packet(packet);
-		}
+        if (packet) {
+                if (packet->trace && packet->trace->format->fin_packet) {
+                        packet->trace->format->fin_packet(packet);
+                }
 
                 if (packet->srcbucket && packet->internalid != 0) {
-                        libtrace_bucket_t *b = (libtrace_bucket_t *)packet->srcbucket;
+                        libtrace_bucket_t *b =
+                                (libtrace_bucket_t *)packet->srcbucket;
                         libtrace_release_bucket_id(b, packet->internalid);
                 }
 
                 if (packet->trace) {
-			if (!libtrace_parallel && packet->trace->last_packet == packet)
-				packet->trace->last_packet = NULL;
+                        if (!libtrace_parallel &&
+                            packet->trace->last_packet == packet) {
+                                packet->trace->last_packet = NULL;
+                        }
                 }
 
-		// No matter what we remove the header and link pointers
-		packet->trace = NULL;
-		packet->header = NULL;
-		packet->payload = NULL;
+                // No matter what we remove the header and link pointers
+                packet->trace = NULL;
+                packet->header = NULL;
+                packet->payload = NULL;
 
-		if (packet->buf_control != TRACE_CTRL_PACKET)
-		{
-			packet->buffer = NULL;
-		}
+                if (packet->buf_control != TRACE_CTRL_PACKET) {
+                        packet->buffer = NULL;
+                }
 
-		trace_clear_cache(packet);
-		packet->hash = 0;
-		packet->order = 0;
+                trace_clear_cache(packet);
+                packet->hash = 0;
+                packet->order = 0;
                 packet->srcbucket = NULL;
                 packet->fmtdata = NULL;
         }

--- a/lib/trace.c
+++ b/lib/trace.c
@@ -1044,7 +1044,7 @@ void trace_fin_packet(libtrace_packet_t *packet) {
 
                 if (packet->srcbucket && packet->internalid != 0) {
                         libtrace_bucket_t *b =
-                                (libtrace_bucket_t *)packet->srcbucket;
+                            (libtrace_bucket_t *)packet->srcbucket;
                         libtrace_release_bucket_id(b, packet->internalid);
                 }
 

--- a/tools/tracertstats/tracertstats.c
+++ b/tools/tracertstats/tracertstats.c
@@ -90,7 +90,7 @@ struct libtrace_t *currenttrace;
 
 static void cleanup_signal(int signal UNUSED) {
         if (currenttrace) {
-                trace_pstop(currenttrace);
+                trace_interrupt();
         }
 }
 


### PR DESCRIPTION
 * fix memory leaks caused by internal libtrace packet copy operations
 * fix race condition due to the use of a shared decoder to calculate capture / wire length
 * fix issues caused by a perpkt thread count mismatch
 * fix a variety of little memory issues (minor leaks, uninitialised variables, double frees etc.)
 * add methods to the simple circular buffer for getting the total size and space available
 * tracertstats: use `trace_interrupt()` instead of `trace_pstop()` when handling a halt signal