### PR TITLE
ETSI memory leak fix + nice to haves

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -115,6 +115,22 @@ AC_ARG_ENABLE(address-san, AS_HELP_STRING(--enable-address-san, Enable address a
   fi
  ], [])
 
+AC_ARG_ENABLE(thread-san, AS_HELP_STRING(--enable-thread-san, Enable thread sanitisation),
+[
+  if test "x$enableval" = xyes ; then
+    if test "x$enable_address_san" = xyes ; then
+        AC_MSG_ERROR("--enable-address-san and --enable-thread-san cannot be used together")
+    fi
+    CFLAGS+=" -fsanitize=thread -fno-omit-frame-pointer -ggdb3"
+    CXXFLAGS+=" -fsanitize=thread -fno-omit-frame-pointer -ggdb3"
+    LDFLAGS+=" -fsanitize=thread -fno-omit-frame-pointer -ggdb3"
+
+    AC_MSG_NOTICE([Compiling with -fsanitize=thread])
+    AC_MSG_NOTICE([ - Build tests using the command: make thread-san])
+    AC_MSG_NOTICE([ - Programs must also be compiled with -fsanitize=thread])
+  fi
+ ], [])
+
 # Check for -fvisibility
 gl_VISIBILITY
 

--- a/test/Makefile
+++ b/test/Makefile
@@ -41,6 +41,9 @@ install:
 address-san: CFLAGS+= -fsanitize=undefined,leak,address -fno-omit-frame-pointer -ggdb3
 address-san: all
 
+thread-san: CFLAGS+= -fsanitize=thread -fno-omit-frame-pointer -ggdb3
+thread-san: all
+
 dpdk: LDLIBS+= -L$(DPDK_BUILD)/libs
 dpdk: INCLUDE+= -I$(DPDK_BUILD)/include
 dpdk: all

--- a/test/do-live-tests.sh
+++ b/test/do-live-tests.sh
@@ -70,7 +70,11 @@ declare -a dag_formats=()
 if [[ $# -eq 0 ]]; then
 	declare -a write_formats=("pcapint:veth0" "int:veth0" "ring:veth0" "dpdkvdev:net_pcap0,iface=veth0" "xdp:veth0")
 	declare -a read_formats=("pcapint:veth1" "int:veth1" "ring:veth1" "dpdkvdev:net_pcap1,iface=veth1" "xdp:veth1")
-	declare -a dag_formats=("dag:/dev/dag16,0")
+	if [ -f "/dev/dag16" ]; then
+		dag_formats+=("dag:/dev/dag16,0")
+	else
+		echo "Skipping DAG test: /dev/dag16 not found; configure with dagload"
+	fi
 fi
 
 while [[ $# -gt 0 ]]; do


### PR DESCRIPTION
Most notably fixes a memory leak, `etsi_socket->srcaddr` was not being free()'d in handful of cases.

Additionally add:
 * Check to only run vDAG tests if a vDAG device is present
 * Thread-sanitizer (`--enable-thread-san`) option to configure (works like address-sanitizer)