### PR TITLE
Update to be able to build against DPDK 21.11

### DIFF
--- a/.github/workflows/dpdk.yaml
+++ b/.github/workflows/dpdk.yaml
@@ -33,8 +33,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04]
-        dpdk_version: [dpdk-20.11, dpdk-20.02, dpdk-19.11.5, dpdk-18.11.10, dpdk-17.11.10, dpdk-16.11.11]
+        os: [ubuntu-22.04, ubuntu-20.04]
+        dpdk_version: [dpdk-21.11, dpdk-20.11, dpdk-20.02, dpdk-19.11.5, dpdk-18.11.10, dpdk-17.11.10, dpdk-16.11.11]
         exclude:
           - os: ubuntu-16.04
             dpdk_version: dpdk-20.11

--- a/lib/combiner_ordered.c
+++ b/lib/combiner_ordered.c
@@ -264,8 +264,8 @@ static void combiner_pause(libtrace_t *trace, libtrace_combine_t *c)
         libtrace_queue_t *queues = c->queues;
         int i;
         for (i = 0; i < trace_get_perpkt_threads(trace); i++) {
-		libtrace_deque_apply_function(&queues[i], (deque_data_fn) libtrace_make_result_safe);
-	}
+                libtrace_deque_apply_function(&queues[i], (deque_data_fn) libtrace_make_result_safe);
+        }
 }
 
 DLLEXPORT const libtrace_combine_t combiner_ordered = {

--- a/lib/combiner_ordered.c
+++ b/lib/combiner_ordered.c
@@ -223,11 +223,13 @@ inline static void read_internal(libtrace_t *trace, libtrace_combine_t *c, const
 	}
 }
 
-static void combiner_read(libtrace_t *trace, libtrace_combine_t *c) {
-	read_internal(trace, c, false);
+static void combiner_read(libtrace_t *trace, libtrace_combine_t *c)
+{
+        read_internal(trace, c, false);
 }
 
-static void combiner_read_final(libtrace_t *trace, libtrace_combine_t *c) {
+static void combiner_read_final(libtrace_t *trace, libtrace_combine_t *c)
+{
         int empty = 0, i;
         libtrace_queue_t *q = c->queues;
 
@@ -257,9 +259,9 @@ static void destroy(libtrace_t *trace, libtrace_combine_t *c) {
 	queues = NULL;
 }
 
-
-static void combiner_pause(libtrace_t *trace, libtrace_combine_t *c) {
-	libtrace_queue_t *queues = c->queues;
+static void combiner_pause(libtrace_t *trace, libtrace_combine_t *c)
+{
+        libtrace_queue_t *queues = c->queues;
 	int i;
 	for (i = 0; i < trace_get_perpkt_threads(trace); i++) {
 		libtrace_deque_apply_function(&queues[i], (deque_data_fn) libtrace_make_result_safe);
@@ -267,14 +269,14 @@ static void combiner_pause(libtrace_t *trace, libtrace_combine_t *c) {
 }
 
 DLLEXPORT const libtrace_combine_t combiner_ordered = {
-	init_combiner,	/* initialise */
-	destroy,		/* destroy */
-	publish,		/* publish */
-	combiner_read,			/* read */
-	combiner_read_final,		/* read_final */
-	combiner_pause,			/* pause */
-	NULL,			/* queues */
-        0,                      /* last_count_tick */
-        0,                      /* last_ts_tick */
-	{0}				/* opts */
+    init_combiner,       /* initialise */
+    destroy,             /* destroy */
+    publish,             /* publish */
+    combiner_read,       /* read */
+    combiner_read_final, /* read_final */
+    combiner_pause,      /* pause */
+    NULL,                /* queues */
+    0,                   /* last_count_tick */
+    0,                   /* last_ts_tick */
+    {0}                  /* opts */
 };

--- a/lib/combiner_ordered.c
+++ b/lib/combiner_ordered.c
@@ -263,7 +263,7 @@ static void combiner_pause(libtrace_t *trace, libtrace_combine_t *c)
 {
         libtrace_queue_t *queues = c->queues;
         int i;
-	for (i = 0; i < trace_get_perpkt_threads(trace); i++) {
+        for (i = 0; i < trace_get_perpkt_threads(trace); i++) {
 		libtrace_deque_apply_function(&queues[i], (deque_data_fn) libtrace_make_result_safe);
 	}
 }

--- a/lib/combiner_ordered.c
+++ b/lib/combiner_ordered.c
@@ -264,7 +264,8 @@ static void combiner_pause(libtrace_t *trace, libtrace_combine_t *c)
         libtrace_queue_t *queues = c->queues;
         int i;
         for (i = 0; i < trace_get_perpkt_threads(trace); i++) {
-                libtrace_deque_apply_function(&queues[i], (deque_data_fn) libtrace_make_result_safe);
+                libtrace_deque_apply_function(
+                    &queues[i], (deque_data_fn)libtrace_make_result_safe);
         }
 }
 

--- a/lib/combiner_ordered.c
+++ b/lib/combiner_ordered.c
@@ -223,11 +223,11 @@ inline static void read_internal(libtrace_t *trace, libtrace_combine_t *c, const
 	}
 }
 
-static void read(libtrace_t *trace, libtrace_combine_t *c) {
+static void combiner_read(libtrace_t *trace, libtrace_combine_t *c) {
 	read_internal(trace, c, false);
 }
 
-static void read_final(libtrace_t *trace, libtrace_combine_t *c) {
+static void combiner_read_final(libtrace_t *trace, libtrace_combine_t *c) {
         int empty = 0, i;
         libtrace_queue_t *q = c->queues;
 
@@ -258,7 +258,7 @@ static void destroy(libtrace_t *trace, libtrace_combine_t *c) {
 }
 
 
-static void pause(libtrace_t *trace, libtrace_combine_t *c) {
+static void combiner_pause(libtrace_t *trace, libtrace_combine_t *c) {
 	libtrace_queue_t *queues = c->queues;
 	int i;
 	for (i = 0; i < trace_get_perpkt_threads(trace); i++) {
@@ -270,9 +270,9 @@ DLLEXPORT const libtrace_combine_t combiner_ordered = {
 	init_combiner,	/* initialise */
 	destroy,		/* destroy */
 	publish,		/* publish */
-	read,			/* read */
-	read_final,		/* read_final */
-	pause,			/* pause */
+	combiner_read,			/* read */
+	combiner_read_final,		/* read_final */
+	combiner_pause,			/* pause */
 	NULL,			/* queues */
         0,                      /* last_count_tick */
         0,                      /* last_ts_tick */

--- a/lib/combiner_ordered.c
+++ b/lib/combiner_ordered.c
@@ -262,7 +262,7 @@ static void destroy(libtrace_t *trace, libtrace_combine_t *c) {
 static void combiner_pause(libtrace_t *trace, libtrace_combine_t *c)
 {
         libtrace_queue_t *queues = c->queues;
-	int i;
+        int i;
 	for (i = 0; i < trace_get_perpkt_threads(trace); i++) {
 		libtrace_deque_apply_function(&queues[i], (deque_data_fn) libtrace_make_result_safe);
 	}

--- a/lib/combiner_sorted.c
+++ b/lib/combiner_sorted.c
@@ -52,8 +52,9 @@ static void publish(libtrace_t *trace UNUSED, int t_id, libtrace_combine_t *c, l
 }
 
 static void combiner_read(libtrace_t *trace UNUSED,
-                libtrace_combine_t *c UNUSED){
-	return;
+                          libtrace_combine_t *c UNUSED)
+{
+        return;
 }
 
 static int compare_result(const void* p1, const void* p2)
@@ -68,16 +69,18 @@ static int compare_result(const void* p1, const void* p2)
 		return 1;
 }
 
-static void combiner_pause(libtrace_t *trace, libtrace_combine_t *c) {
-	libtrace_vector_t *queues = c->queues;
+static void combiner_pause(libtrace_t *trace, libtrace_combine_t *c)
+{
+        libtrace_vector_t *queues = c->queues;
 	int i;
 	for (i = 0; i < trace_get_perpkt_threads(trace); ++i) {
 		libtrace_vector_apply_function(&queues[i], (vector_data_fn) libtrace_make_result_safe);
 	}
 }
 
-static void combiner_read_final(libtrace_t *trace, libtrace_combine_t *c) {
-	libtrace_vector_t *queues = c->queues;
+static void combiner_read_final(libtrace_t *trace, libtrace_combine_t *c)
+{
+        libtrace_vector_t *queues = c->queues;
 	int i;
 	size_t a;
 	// Combine all results into queue 1
@@ -120,14 +123,14 @@ static void destroy(libtrace_t *trace, libtrace_combine_t *c) {
 }
 
 DLLEXPORT const libtrace_combine_t combiner_sorted = {
-    init_combiner,	/* initialise */
-	destroy,		/* destroy */
-	publish,		/* publish */
-    combiner_read,			/* read */
-    combiner_read_final,			/* read_final */
-    combiner_pause,			/* pause */
-    NULL,			/* queues */
-    0,                          /* last_count_tick */
-    0,                          /* last_ts_tick */
-    {0}				/* opts */
+    init_combiner,       /* initialise */
+    destroy,             /* destroy */
+    publish,             /* publish */
+    combiner_read,       /* read */
+    combiner_read_final, /* read_final */
+    combiner_pause,      /* pause */
+    NULL,                /* queues */
+    0,                   /* last_count_tick */
+    0,                   /* last_ts_tick */
+    {0}                  /* opts */
 };

--- a/lib/combiner_sorted.c
+++ b/lib/combiner_sorted.c
@@ -72,7 +72,7 @@ static int compare_result(const void* p1, const void* p2)
 static void combiner_pause(libtrace_t *trace, libtrace_combine_t *c)
 {
         libtrace_vector_t *queues = c->queues;
-	int i;
+        int i;
 	for (i = 0; i < trace_get_perpkt_threads(trace); ++i) {
 		libtrace_vector_apply_function(&queues[i], (vector_data_fn) libtrace_make_result_safe);
 	}
@@ -81,7 +81,7 @@ static void combiner_pause(libtrace_t *trace, libtrace_combine_t *c)
 static void combiner_read_final(libtrace_t *trace, libtrace_combine_t *c)
 {
         libtrace_vector_t *queues = c->queues;
-	int i;
+        int i;
 	size_t a;
 	// Combine all results into queue 1
 	for (i = 1; i < trace_get_perpkt_threads(trace); ++i)

--- a/lib/combiner_sorted.c
+++ b/lib/combiner_sorted.c
@@ -73,7 +73,7 @@ static void combiner_pause(libtrace_t *trace, libtrace_combine_t *c)
 {
         libtrace_vector_t *queues = c->queues;
         int i;
-	for (i = 0; i < trace_get_perpkt_threads(trace); ++i) {
+        for (i = 0; i < trace_get_perpkt_threads(trace); ++i) {
 		libtrace_vector_apply_function(&queues[i], (vector_data_fn) libtrace_make_result_safe);
 	}
 }
@@ -82,7 +82,7 @@ static void combiner_read_final(libtrace_t *trace, libtrace_combine_t *c)
 {
         libtrace_vector_t *queues = c->queues;
         int i;
-	size_t a;
+        size_t a;
 	// Combine all results into queue 1
 	for (i = 1; i < trace_get_perpkt_threads(trace); ++i)
 	{

--- a/lib/combiner_sorted.c
+++ b/lib/combiner_sorted.c
@@ -51,7 +51,8 @@ static void publish(libtrace_t *trace UNUSED, int t_id, libtrace_combine_t *c, l
 	libtrace_vector_push_back(vec, res);
 }
 
-static void read(libtrace_t *trace UNUSED, libtrace_combine_t *c UNUSED){
+static void combiner_read(libtrace_t *trace UNUSED,
+                libtrace_combine_t *c UNUSED){
 	return;
 }
 
@@ -67,7 +68,7 @@ static int compare_result(const void* p1, const void* p2)
 		return 1;
 }
 
-static void pause(libtrace_t *trace, libtrace_combine_t *c) {
+static void combiner_pause(libtrace_t *trace, libtrace_combine_t *c) {
 	libtrace_vector_t *queues = c->queues;
 	int i;
 	for (i = 0; i < trace_get_perpkt_threads(trace); ++i) {
@@ -75,7 +76,7 @@ static void pause(libtrace_t *trace, libtrace_combine_t *c) {
 	}
 }
 
-static void read_final(libtrace_t *trace, libtrace_combine_t *c) {
+static void combiner_read_final(libtrace_t *trace, libtrace_combine_t *c) {
 	libtrace_vector_t *queues = c->queues;
 	int i;
 	size_t a;
@@ -122,9 +123,9 @@ DLLEXPORT const libtrace_combine_t combiner_sorted = {
     init_combiner,	/* initialise */
 	destroy,		/* destroy */
 	publish,		/* publish */
-    read,			/* read */
-    read_final,			/* read_final */
-    pause,			/* pause */
+    combiner_read,			/* read */
+    combiner_read_final,			/* read_final */
+    combiner_pause,			/* pause */
     NULL,			/* queues */
     0,                          /* last_count_tick */
     0,                          /* last_ts_tick */

--- a/lib/combiner_sorted.c
+++ b/lib/combiner_sorted.c
@@ -74,7 +74,8 @@ static void combiner_pause(libtrace_t *trace, libtrace_combine_t *c)
         libtrace_vector_t *queues = c->queues;
         int i;
         for (i = 0; i < trace_get_perpkt_threads(trace); ++i) {
-                libtrace_vector_apply_function(&queues[i], (vector_data_fn) libtrace_make_result_safe);
+                libtrace_vector_apply_function(
+                    &queues[i], (vector_data_fn)libtrace_make_result_safe);
         }
 }
 
@@ -84,26 +85,26 @@ static void combiner_read_final(libtrace_t *trace, libtrace_combine_t *c)
         int i;
         size_t a;
         // Combine all results into queue 1
-	for (i = 1; i < trace_get_perpkt_threads(trace); ++i)
-	{
-		libtrace_vector_append(&queues[0],&queues[i]);
-	}
-	// Sort them
-	libtrace_vector_qsort(&queues[0], compare_result);
+        for (i = 1; i < trace_get_perpkt_threads(trace); ++i) {
+                libtrace_vector_append(&queues[0], &queues[i]);
+        }
+        // Sort them
+        libtrace_vector_qsort(&queues[0], compare_result);
 
-	for (a = 0; a < libtrace_vector_get_size(&queues[0]); ++a) {
-		libtrace_result_t r;
-		libtrace_generic_t gt = {.res = &r};
-		ASSERT_RET (libtrace_vector_get(&queues[0], a, (void *) &r), == 1);
-		if (r.type == RESULT_TICK_INTERVAL ||
-                                r.type == RESULT_TICK_COUNT) {
+        for (a = 0; a < libtrace_vector_get_size(&queues[0]); ++a) {
+                libtrace_result_t r;
+                libtrace_generic_t gt = {.res = &r};
+                ASSERT_RET(libtrace_vector_get(&queues[0], a, (void *)&r),
+                           == 1);
+                if (r.type == RESULT_TICK_INTERVAL ||
+                    r.type == RESULT_TICK_COUNT) {
                         /* Ticks are essentially useless for this combiner? */
                         continue;
                 }
                 send_message(trace, &trace->reporter_thread, MESSAGE_RESULT,
                                 gt, NULL);
-	}
-	libtrace_vector_empty(&queues[0]);
+        }
+        libtrace_vector_empty(&queues[0]);
 }
 
 static void destroy(libtrace_t *trace, libtrace_combine_t *c) {

--- a/lib/combiner_sorted.c
+++ b/lib/combiner_sorted.c
@@ -74,8 +74,8 @@ static void combiner_pause(libtrace_t *trace, libtrace_combine_t *c)
         libtrace_vector_t *queues = c->queues;
         int i;
         for (i = 0; i < trace_get_perpkt_threads(trace); ++i) {
-		libtrace_vector_apply_function(&queues[i], (vector_data_fn) libtrace_make_result_safe);
-	}
+                libtrace_vector_apply_function(&queues[i], (vector_data_fn) libtrace_make_result_safe);
+        }
 }
 
 static void combiner_read_final(libtrace_t *trace, libtrace_combine_t *c)
@@ -83,7 +83,7 @@ static void combiner_read_final(libtrace_t *trace, libtrace_combine_t *c)
         libtrace_vector_t *queues = c->queues;
         int i;
         size_t a;
-	// Combine all results into queue 1
+        // Combine all results into queue 1
 	for (i = 1; i < trace_get_perpkt_threads(trace); ++i)
 	{
 		libtrace_vector_append(&queues[0],&queues[i]);

--- a/lib/combiner_unordered.c
+++ b/lib/combiner_unordered.c
@@ -55,8 +55,9 @@ static void publish(libtrace_t *trace, int t_id, libtrace_combine_t *c, libtrace
 	}
 }
 
-static void combiner_read(libtrace_t *trace, libtrace_combine_t *c){
-	libtrace_queue_t *queues = c->queues;
+static void combiner_read(libtrace_t *trace, libtrace_combine_t *c)
+{
+        libtrace_queue_t *queues = c->queues;
 	int i;
 
 	/* Loop through and read all that are here */
@@ -100,14 +101,14 @@ static void destroy(libtrace_t *trace, libtrace_combine_t *c) {
 }
 
 DLLEXPORT const libtrace_combine_t combiner_unordered = {
-    init_combiner,	/* initialise */
-	destroy,		/* destroy */
-	publish,		/* publish */
-    combiner_read,			/* read */
-    combiner_read,			/* read_final */
-    combiner_read,			/* pause */
-    NULL,			/* queues */
-    0,                          /* last_count_tick */
-    0,                          /* last_ts_tick */
-    {0}				/* opts */
+    init_combiner, /* initialise */
+    destroy,       /* destroy */
+    publish,       /* publish */
+    combiner_read, /* read */
+    combiner_read, /* read_final */
+    combiner_read, /* pause */
+    NULL,          /* queues */
+    0,             /* last_count_tick */
+    0,             /* last_ts_tick */
+    {0}            /* opts */
 };

--- a/lib/combiner_unordered.c
+++ b/lib/combiner_unordered.c
@@ -61,7 +61,7 @@ static void combiner_read(libtrace_t *trace, libtrace_combine_t *c)
         int i;
 
         /* Loop through and read all that are here */
-	for (i = 0; i < trace_get_perpkt_threads(trace); ++i) {
+        for (i = 0; i < trace_get_perpkt_threads(trace); ++i) {
 		libtrace_queue_t *v = &queues[i];
 		while (libtrace_deque_get_size(v) != 0) {
 			libtrace_result_t r;

--- a/lib/combiner_unordered.c
+++ b/lib/combiner_unordered.c
@@ -58,7 +58,7 @@ static void publish(libtrace_t *trace, int t_id, libtrace_combine_t *c, libtrace
 static void combiner_read(libtrace_t *trace, libtrace_combine_t *c)
 {
         libtrace_queue_t *queues = c->queues;
-	int i;
+        int i;
 
 	/* Loop through and read all that are here */
 	for (i = 0; i < trace_get_perpkt_threads(trace); ++i) {

--- a/lib/combiner_unordered.c
+++ b/lib/combiner_unordered.c
@@ -60,7 +60,7 @@ static void combiner_read(libtrace_t *trace, libtrace_combine_t *c)
         libtrace_queue_t *queues = c->queues;
         int i;
 
-	/* Loop through and read all that are here */
+        /* Loop through and read all that are here */
 	for (i = 0; i < trace_get_perpkt_threads(trace); ++i) {
 		libtrace_queue_t *v = &queues[i];
 		while (libtrace_deque_get_size(v) != 0) {

--- a/lib/combiner_unordered.c
+++ b/lib/combiner_unordered.c
@@ -55,7 +55,7 @@ static void publish(libtrace_t *trace, int t_id, libtrace_combine_t *c, libtrace
 	}
 }
 
-static void read(libtrace_t *trace, libtrace_combine_t *c){
+static void combiner_read(libtrace_t *trace, libtrace_combine_t *c){
 	libtrace_queue_t *queues = c->queues;
 	int i;
 
@@ -103,9 +103,9 @@ DLLEXPORT const libtrace_combine_t combiner_unordered = {
     init_combiner,	/* initialise */
 	destroy,		/* destroy */
 	publish,		/* publish */
-    read,			/* read */
-    read,			/* read_final */
-    read,			/* pause */
+    combiner_read,			/* read */
+    combiner_read,			/* read_final */
+    combiner_read,			/* pause */
     NULL,			/* queues */
     0,                          /* last_count_tick */
     0,                          /* last_ts_tick */

--- a/lib/combiner_unordered.c
+++ b/lib/combiner_unordered.c
@@ -62,9 +62,9 @@ static void combiner_read(libtrace_t *trace, libtrace_combine_t *c)
 
         /* Loop through and read all that are here */
         for (i = 0; i < trace_get_perpkt_threads(trace); ++i) {
-		libtrace_queue_t *v = &queues[i];
-		while (libtrace_deque_get_size(v) != 0) {
-			libtrace_result_t r;
+                libtrace_queue_t *v = &queues[i];
+                while (libtrace_deque_get_size(v) != 0) {
+                        libtrace_result_t r;
                         libtrace_generic_t gt = {.res = &r};
 			ASSERT_RET (libtrace_deque_pop_front(v, (void *) &r), == 1);
                         /* Ignore any ticks that we've already seen */
@@ -81,8 +81,8 @@ static void combiner_read(libtrace_t *trace, libtrace_combine_t *c)
                         }
 			send_message(trace, &trace->reporter_thread,
                                 MESSAGE_RESULT, gt, NULL);
-		}
-	}
+                }
+        }
 }
 
 static void destroy(libtrace_t *trace, libtrace_combine_t *c) {

--- a/lib/format_dpdk.c
+++ b/lib/format_dpdk.c
@@ -712,7 +712,7 @@ static portid_t dpdk_get_port_id(const char *uri)
 #if defined(RTE_ETH_FOREACH_MATCHING_DEV) || defined(USE_DEV_ATTACH)
 UNUSED static struct rte_device *dpdk_get_device_from_port(portid_t port)
 {
-#        if RTE_VERSION >= RTE_VERSION_NUM(18, 5, 0, 1)
+#        if RTE_VERSION >= RTE_VERSION_NUM(19, 11, 0, 1)
         struct rte_eth_dev_info dev_info;
         if (rte_eth_dev_info_get(port, &dev_info) != 0) {
                 return NULL;

--- a/lib/format_dpdk.c
+++ b/lib/format_dpdk.c
@@ -712,7 +712,13 @@ static portid_t dpdk_get_port_id(const char *uri)
 #if defined(RTE_ETH_FOREACH_MATCHING_DEV) || defined(USE_DEV_ATTACH)
 UNUSED static struct rte_device *dpdk_get_device_from_port(portid_t port)
 {
-#        if RTE_VERSION >= RTE_VERSION_NUM(17, 2, 0, 1)
+#        if RTE_VERSION >= RTE_VERSION_NUM(18, 5, 0, 1)
+        struct rte_eth_dev_info dev_info;
+        if (rte_eth_dev_info_get(port, &dev_info) != 0) {
+                return NULL;
+        }
+        return dev_info.device;
+#        elif RTE_VERSION >= RTE_VERSION_NUM(17, 2, 0, 1)
         return rte_eth_devices[port].device;
 #        else
         return &rte_eth_devices[port].pci_dev->device;
@@ -833,8 +839,9 @@ static int dpdk_attach_device(char *uridata,
  */
 static int dpdk_close_and_detach_device(portid_t port)
 {
+        struct rte_device *dev;
 #ifdef RTE_ETH_FOREACH_MATCHING_DEV
-        struct rte_device *dev = dpdk_get_device_from_port(port);
+        dev = dpdk_get_device_from_port(port);
 #endif
         /* Close the device completely, device cannot be restarted */
         rte_eth_dev_close(port);
@@ -846,7 +853,8 @@ static int dpdk_close_and_detach_device(portid_t port)
         return 0;
 #elif defined(USE_DEV_ATTACH)
 #        if RTE_VERSION >= RTE_VERSION_NUM(17, 8, 0, 1)
-        if (rte_eal_dev_detach(dpdk_get_device_from_port(port))) {
+        dev = dpdk_get_device_from_port(port);
+        if (dev == NULL || rte_eal_dev_detach(dev)) {
                 fprintf(stderr, "rte_eal_dev_detach failed\n");
                 return -1;
         }
@@ -1076,7 +1084,7 @@ int dpdk_config_input(libtrace_t *libtrace, trace_option_t option, void *data)
  * max_rx_pkt_len and jumbo_frame. This can be limited to less than
  *
  */
-static struct rte_eth_conf port_conf = {.rxmode = {.mq_mode = ETH_RSS,
+static struct rte_eth_conf port_conf = {.rxmode = {.mq_mode = RTE_ETH_MQ_RX_RSS,
                                                    .split_hdr_size = 0,
 
 #if RTE_VERSION >= RTE_VERSION_NUM(18, 8, 0, 1)
@@ -1124,7 +1132,7 @@ static struct rte_eth_conf port_conf = {.rxmode = {.mq_mode = ETH_RSS,
                                         },
                                         .txmode =
                                             {
-                                                .mq_mode = ETH_DCB_NONE,
+                                                .mq_mode = RTE_ETH_MQ_TX_NONE,
                                             },
                                         .rx_adv_conf =
                                             {
@@ -1526,12 +1534,17 @@ static int dpdk_start_streams(struct dpdk_format_data_t *format_data, char *err,
                  * then packets are returned unchanged.
                  */
                 buf_size = RX_MBUF_SIZE;
-#if RTE_VERSION >= RTE_VERSION_NUM(18, 8, 0, 1)
+#ifdef DEV_RX_OFFLOAD_JUMBO_FRAME
                 port_conf.rxmode.offloads &= (~(DEV_RX_OFFLOAD_JUMBO_FRAME));
-#else
+#elif RTE_VERSION < RTE_VERSION_NUM(18, 8, 0, 1)
                 port_conf.rxmode.jumbo_frame = 0;
 #endif
+
+#if RTE_VERSION >= RTE_VERSION_NUM(21, 11, 0, 1)
+                port_conf.rxmode.mtu = 0;
+#else
                 port_conf.rxmode.max_rx_pkt_len = 0;
+#endif
         } else {
                 /* We need jumbo frames */
                 double expn;
@@ -1555,11 +1568,17 @@ static int dpdk_start_streams(struct dpdk_format_data_t *format_data, char *err,
                                 " not support jumbo frames snaplen %d\n",
                                 format_data->snaplen);
                 }
-#else /* not def DEV_RX_OFFLOAD_JUMBO_FRAME, must assume support */
+#elif RTE_VERSION < RTE_VERSION_NUM(21, 11, 0, 1)
+                /* not def DEV_RX_OFFLOAD_JUMBO_FRAME, must assume support */
                 port_conf.rxmode.jumbo_frame = 1;
 #endif
                 buf_size = format_data->snaplen;
+
+#if RTE_VERSION < RTE_VERSION_NUM(21, 11, 0, 1)
                 port_conf.rxmode.max_rx_pkt_len = buf_size;
+#else
+                port_conf.rxmode.mtu = buf_size;
+#endif
 
                 /* Use fewer buffers if we're supporting jumbo frames
                  * otherwise we won't be able to allocate memory.

--- a/lib/format_dpdk.h
+++ b/lib/format_dpdk.h
@@ -197,6 +197,16 @@ typedef uint8_t portid_t;
 #        define rte_get_main_lcore rte_get_master_lcore
 #endif
 
+/* 21.11 renames a bunch of RX MQ mode #defines */
+#ifndef RTE_ETH_MQ_RX_RSS
+#define RTE_ETH_MQ_RX_RSS ETH_MQ_RX_RSS
+#endif
+
+#ifndef RTE_ETH_MQ_TX_NONE
+#define RTE_ETH_MQ_TX_NONE ETH_MQ_TX_NONE
+#endif
+
+
 /* https://github.com/DPDK/dpdk/commit/35b2d13 19.08-rc1
  * renames ETHER_CRC_LEN -> RTE_ETHER_CRC_LEN */
 #ifndef RTE_ETHER_CRC_LEN

--- a/lib/format_dpdk.h
+++ b/lib/format_dpdk.h
@@ -199,13 +199,12 @@ typedef uint8_t portid_t;
 
 /* 21.11 renames a bunch of RX MQ mode #defines */
 #ifndef RTE_ETH_MQ_RX_RSS
-#define RTE_ETH_MQ_RX_RSS ETH_MQ_RX_RSS
+#        define RTE_ETH_MQ_RX_RSS ETH_MQ_RX_RSS
 #endif
 
 #ifndef RTE_ETH_MQ_TX_NONE
-#define RTE_ETH_MQ_TX_NONE ETH_MQ_TX_NONE
+#        define RTE_ETH_MQ_TX_NONE ETH_MQ_TX_NONE
 #endif
-
 
 /* https://github.com/DPDK/dpdk/commit/35b2d13 19.08-rc1
  * renames ETHER_CRC_LEN -> RTE_ETHER_CRC_LEN */

--- a/test/do-test-build-dpdk.sh
+++ b/test/do-test-build-dpdk.sh
@@ -176,7 +176,7 @@ do
 			echo "CONFIG_RTE_LIBRTE_PMD_PCAP=y" >> "$DPDK_CONFIG"
 			echo "CONFIG_RTE_EAL_IGB_UIO=n" >> "$DPDK_CONFIG"
 			do_test make install T=x86_64-native-linuxapp-gcc \
-					     EXTRA_CFLAGS="-fPIC -w -ggdb" -j $BUILD_THREADS \
+					     EXTRA_CFLAGS="-fcommon -fPIC -w -ggdb" -j $BUILD_THREADS \
 					     > build_stdout.txt 2> build_stderr.txt
 			ret=$?
 		else
@@ -185,10 +185,10 @@ do
 	else
 		echo "	Building using meson"
 		mkdir install
-		if CFLAGS="-ggdb3 -w" do_test meson --prefix=$(pwd)/install build \
+		if CFLAGS="-fcommon -ggdb3 -w" do_test meson --prefix=$(pwd)/install build \
 				> build_stdout.txt 2> build_stderr.txt ; then
 			cd ./build
-			CFLAGS="-ggdb3 -w" do_test meson install > ../build_stdout.txt 2> ../build_stderr.txt
+			CFLAGS="-fcommon -ggdb3 -w" do_test meson install > ../build_stdout.txt 2> ../build_stderr.txt
 			ret=$?
 			cd ..
 		else

--- a/test/do-test-build-dpdk.sh
+++ b/test/do-test-build-dpdk.sh
@@ -105,13 +105,14 @@ declare -a dpdk_versions=(
 	"dpdk-19.11.5.tar.gz"
 	"dpdk-20.02.tar.gz"
 	"dpdk-20.11.tar.gz"
+	"dpdk-21.11.tar.gz"
 	)
 
 while [[ $# -gt 0 ]]; do
 	dpdk_versions=()
         key="$1"
         case $key in
-        dpdk-16.11.11|dpdk-17.11.10|dpdk-18.11.10|dpdk-19.11.5|dpdk-20.02|dpdk-20.11)
+        dpdk-16.11.11|dpdk-17.11.10|dpdk-18.11.10|dpdk-19.11.5|dpdk-20.02|dpdk-20.11|dpdk-21.11)
 		dpdk_versions+=("$key.tar.gz")
 		;;
 	*)


### PR DESCRIPTION
As per usual, the DPDK release packaged for Ubuntu 22.04 removes or changes various API/ABIs that we have been using.

This PR resolves those issues, as well as a few others that cropped up during testing.

@rsanger if you have the time and inclination to look over this PR and double check I haven't done anything stupid, that would be great thanks ;)

Other changes:
 * renamed `read()` and `pause()` methods in combiner code to avoid clashing with `read()` and `pause()` if `unistd.h` gets included somewhere along the way
 * added Ubuntu 22.04 to DPDK test matrix (22.04 has gcc >= 10 which introduces some issues for older DPDK releases)
 * added DPDK 21.11 to DPDK test matrix
 * DPDK build tests now set `-fcommon` CFLAG by default to account for previously mentioned gcc10-isms