### PR TITLE
Fix inverted XDP copy/zero-copy bind flag handling

### DIFF
--- a/lib/format_linux_xdp.c
+++ b/lib/format_linux_xdp.c
@@ -1604,16 +1604,16 @@ static int linux_xdp_config_input(libtrace_t *libtrace, trace_option_t options,
         XDP_FORMAT_DATA->cfg.xdp_flags &= ~XDP_FLAGS_MODES;
         XDP_FORMAT_DATA->cfg.xdp_flags |= XDP_FLAGS_SKB_MODE;
         /* cannot use zero copy mode with SKB so force copy */
-        XDP_FORMAT_DATA->cfg.xsk_bind_flags &= XDP_COPY;
-        XDP_FORMAT_DATA->cfg.xsk_bind_flags |= XDP_ZEROCOPY;
-        return 0;
-    case TRACE_OPTION_XDP_ZERO_COPY_MODE:
-        XDP_FORMAT_DATA->cfg.xsk_bind_flags &= XDP_ZEROCOPY;
+        XDP_FORMAT_DATA->cfg.xsk_bind_flags &= ~XDP_ZEROCOPY;
         XDP_FORMAT_DATA->cfg.xsk_bind_flags |= XDP_COPY;
         return 0;
-    case TRACE_OPTION_XDP_COPY_MODE:
-        XDP_FORMAT_DATA->cfg.xsk_bind_flags &= XDP_COPY;
+    case TRACE_OPTION_XDP_ZERO_COPY_MODE:
+        XDP_FORMAT_DATA->cfg.xsk_bind_flags &= ~XDP_COPY;
         XDP_FORMAT_DATA->cfg.xsk_bind_flags |= XDP_ZEROCOPY;
+        return 0;
+    case TRACE_OPTION_XDP_COPY_MODE:
+        XDP_FORMAT_DATA->cfg.xsk_bind_flags &= ~XDP_ZEROCOPY;
+        XDP_FORMAT_DATA->cfg.xsk_bind_flags |= XDP_COPY;
         return 0;
     }
 

--- a/lib/libtrace.h.in
+++ b/lib/libtrace.h.in
@@ -1648,10 +1648,10 @@ typedef enum {
     /** Install XDP program in SKB (generic) mode */
     TRACE_OPTION_XDP_SKB_MODE,
 
-    /** Force XDP copy mode */
+    /** Force XDP zero copy mode */
     TRACE_OPTION_XDP_ZERO_COPY_MODE,
 
-    /** Force XDP zero copy mode */
+    /** Force XDP copy mode */
     TRACE_OPTION_XDP_COPY_MODE,
 } trace_option_t;
 


### PR DESCRIPTION
TRACE_OPTION_XDP_ZERO_COPY_MODE set XDP_COPY, TRACE_OPTION_XDP_COPY_MODE set XDP_ZEROCOPY, and TRACE_OPTION_XDP_SKB_MODE forced XDP_ZEROCOPY despite the comment saying SKB requires copy mode (the kernel rejects ZEROCOPY binds in SKB mode with EOPNOTSUPP).

The mask operations were also wrong: `flags &= XDP_COPY` keeps only the copy bit rather than clearing it, so the intent of "clear the other mode, set the requested one" was never expressed. Use `&= ~other` + `|= requested` in all three cases.

The doc comments for the two options in libtrace.h.in were swapped the same way; fix those to match the option names.